### PR TITLE
Add Renesas RZ/G3E EVK robotic-arm demo

### DIFF
--- a/renesas-rzg3e-evk/README.md
+++ b/renesas-rzg3e-evk/README.md
@@ -150,6 +150,13 @@ python3 app.py
 
 View the random-integer telemetry data under the "Live Data" tab for your device on /IOTCONNECT.
 
+## More Demos
+
+- [**Robotic Arm**](./robotic-arm/README.md) — control a Hiwonder XArm 1S
+  from the RZ/G3E with a wrist-mounted USB camera. Includes an autonomous
+  ball-pickup mode (HSV detection + visual servoing) and an optional ASL
+  gesture-control mode, with /IOTCONNECT telemetry and remote commands.
+
 # 8. Resources
 
 * [Purchase the Renesas RZ/G3E Evaluation Board Kit](https://www.newark.com/renesas/rtk9947e57s01000be/eval-kit-arm-cortex-a55-m33-64bit/dp/73AM7397)

--- a/renesas-rzg3e-evk/robotic-arm/LICENSE
+++ b/renesas-rzg3e-evk/robotic-arm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Avnet /IOTCONNECT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/renesas-rzg3e-evk/robotic-arm/README.md
+++ b/renesas-rzg3e-evk/robotic-arm/README.md
@@ -1,0 +1,472 @@
+# Renesas RZ/G3E EVK + /IOTCONNECT XArm Vision Demo
+
+Port of the [TRIA Vision AI Kit 6490 robotic-arm demo](https://github.com/avnet-iotconnect/iotc-tria-vision-ai-kit-robotic-arm)
+to the **Renesas RZ/G3E Evaluation Board Kit**. The demo controls a Hiwonder
+XArm 1S over USB and streams telemetry / accepts commands from /IOTCONNECT.
+Two interchangeable vision modes are available, selected at launch with `--mode`:
+
+- **`ball`** (default, recommended on RZ/G3E) — autonomous eye-in-hand visual
+  servoing. A wrist-mounted USB camera segments a colored ball by HSV; the
+  arm pans / tilts / advances on its own to center, approach, and grab it.
+  Only depends on OpenCV + NumPy + the xarm bus-servo library.
+- **`asl`** — American Sign Language gesture control via MediaPipe + a small
+  PointNet model. Heavy ML dependencies (`torch`, `mediapipe`) — **best-effort
+  on the RZ/G3E**, see the [Mode availability](#mode-availability) section.
+
+## TL;DR — fresh-board quick start
+
+After completing the base [Renesas RZ/G3E EVK QuickStart](../README.md):
+
+```bash
+# 1. On the host PC (Git Bash / WSL / Linux):
+ssh root@<BOARD-IP> python3 --version              # confirm: Python 3.12.x
+wget https://raw.githubusercontent.com/avnet-iotconnect/iotc-python-lite-sdk-demos/refs/heads/main/renesas-rzg3e-evk/robotic-arm/scripts/deps-download.sh \
+  && bash ./deps-download.sh <BOARD-IP>
+
+# 2. On the board:
+bash ~/robotic-arm/scripts/deps-install.sh         # expect: cv2, numpy, xarm, hid, avnet... = OK
+
+# 3. (Onboard the device in /IOTCONNECT, download the cert bundle, then
+#     copy + rename the three files to ~/robotic-arm/ — see §4.)
+
+# 4. Calibrate the ball color, then run:
+cd ~/robotic-arm
+./calibrate.sh                                     # browser at http://<BOARD-IP>:8000/
+./start.sh --headless --web-port 8000              # demo + live browser view
+```
+
+Open `http://<BOARD-IP>:8000/` in any browser on the same LAN to watch the
+camera feed with detection overlay during both calibration and the live demo.
+
+## 1. Prerequisites
+
+Complete the base [Renesas RZ/G3E EVK QuickStart](../README.md) first. That
+guide covers flashing the SD-card image, bootloader setup, network bring-up,
+and installing the /IOTCONNECT Lite SDK on the board. This demo additionally
+assumes:
+
+- The board boots, has a working ethernet connection, and you can SSH to it
+  as `root` (the shipped image enables passwordless root SSH).
+- The IoTConnect SDK is installed:
+  `ssh root@<BOARD-IP> python3 -c "import avnet.iotconnect.sdk.lite"` succeeds.
+- The board's Python is **3.12.x** (the shipped Yocto `rz-vlp 5.0.8` image
+  uses 3.12.9). Confirm with `ssh root@<BOARD-IP> python3 --version`. The
+  wheel-download script defaults to `cp312`; if your image differs, override
+  with `PY_VER=cp311 bash deps-download.sh <ip>` or similar.
+
+> [!NOTE]
+> The Yocto image strips several Python stdlib modules (`resource`,
+> `multiprocessing`, `statistics`). The demo source has been written to
+> not depend on any of them — but if you adapt the code, be aware that
+> packages like `psutil` and `py-cpuinfo` will not import here.
+
+## 2. Additional Hardware
+
+In addition to the items in the base QuickStart:
+
+- **[Hiwonder XArm 1S](https://www.amazon.com/LewanSoul-Programmable-Feedback-Parameter-Programming/dp/B0CHY63V9P?th=1)** —
+  USB-connected 6-DOF robotic arm with gripper. Powered separately from the
+  RZ/G3E.
+- **USB camera** — a UVC-class USB webcam (verified with the Logitech Brio
+  100 and the eMeet C960). Mount on the wrist-roll servo with zip ties so it
+  pitches with the gripper. A bare USB-camera PCB module behind the gripper
+  jaws is best for `ball` mode (cleanest line of sight, removes parallax).
+  The kernel exposes the camera as `/dev/video0` on this board.
+
+You do **not** need an HDMI monitor. The RZ/G3E ships without a working
+display server, and the demo is designed to be operated entirely from a
+host PC (terminal over SSH, browser for video). If you have a USB hub
+between the board and the camera + arm, prefer a **powered** hub — the
+Brio 100 + arm together can exceed what a single bus-powered USB-C port
+will deliver.
+
+## 3. Install Demo Dependencies
+
+The base RZ/G3E image does not ship pip repositories, so dependencies are
+fetched on the host PC and transferred to the board (the same pattern the
+base QuickStart uses for the IoTConnect SDK).
+
+1. **Find the board's IP** — on the board's serial console:
+   ```
+   ip a
+   ```
+   Note the `inet` address under `end0`.
+
+2. **On the host PC** (Git Bash / WSL / Linux), confirm the board's Python
+   version (wheel ABI tags must match exactly):
+   ```
+   ssh root@<BOARD-IP> python3 --version
+   ```
+   The shipped image uses Python **3.12**, which is the script's default. If
+   you're on a different image, prepend `PY_VER=cp311` (or the matching tag).
+
+3. Run the download script. It fetches aarch64 wheels for the demo's Python
+   deps, clones the demo source tree, and `scp`'s everything to the board:
+   ```
+   wget https://raw.githubusercontent.com/avnet-iotconnect/iotc-python-lite-sdk-demos/refs/heads/main/renesas-rzg3e-evk/robotic-arm/scripts/deps-download.sh \
+     && bash ./deps-download.sh <BOARD-IP>
+   ```
+   > [!NOTE]
+   > The script will skip `torch`, `torchvision`, and `mediapipe` if no
+   > matching aarch64 wheel is available on PyPI. That's expected — those
+   > packages drive the optional `asl` mode. The required wheels for `ball`
+   > mode (`opencv-python-headless`, `numpy`, `xarm`, `hidapi`, `requests`)
+   > all ship aarch64 wheels.
+
+4. **On the board**, install the transferred wheels:
+   ```
+   bash ~/robotic-arm/scripts/deps-install.sh
+   ```
+   The script ends with a module availability check. On a healthy install
+   you should see:
+   ```
+   Module availability check:
+     OK    : cv2
+     OK    : numpy
+     OK    : xarm
+     OK    : hid
+     OK    : avnet.iotconnect.sdk.lite
+     MISS  : torch                  <-- normal — only needed for `asl` mode
+     MISS  : mediapipe              <-- normal — only needed for `asl` mode
+   ```
+   The `MISS` lines for `torch` / `mediapipe` are expected. If anything
+   else shows `MISS`, see [Troubleshooting](#troubleshooting).
+
+## 4. Onboard the Device to /IOTCONNECT
+
+Follow [this guide](../../common/general-guides/UI-ONBOARD.md) to register
+the RZ/G3E to /IOTCONNECT. You'll get back three files from the cloud
+console — typically with names like:
+
+- `iotcDeviceConfig (N).json`
+- `cert_<deviceID>.crt`
+- `pk_<deviceID>.pem`
+
+The demo expects fixed names. From the host PC, copy them to the board with
+the renames baked in:
+
+```bash
+DOWNLOAD=~/Downloads/<your-cert-folder>
+scp "$DOWNLOAD/iotcDeviceConfig (N).json" root@<BOARD-IP>:~/robotic-arm/iotcDeviceConfig.json
+scp "$DOWNLOAD/cert_<deviceID>.crt"       root@<BOARD-IP>:~/robotic-arm/device-cert.pem
+scp "$DOWNLOAD/pk_<deviceID>.pem"         root@<BOARD-IP>:~/robotic-arm/device-pkey.pem
+ssh root@<BOARD-IP> chmod 600 ~/robotic-arm/device-pkey.pem
+```
+
+Confirm with a quick smoke test on the board:
+
+```
+cd ~/robotic-arm && python3 -c "
+from avnet.iotconnect.sdk.lite import DeviceConfig
+DeviceConfig.from_iotc_device_config_json_file(
+    device_config_json_path='iotcDeviceConfig.json',
+    device_cert_path='device-cert.pem',
+    device_pkey_path='device-pkey.pem',
+); print('iotc config OK')"
+```
+
+The supplied [`robArm2_template.json`](robArm2_template.json) defines the
+device-template attributes the demo publishes (gripper, wrist_roll,
+wrist_flex, elbow_flex, shoulder_lift, shoulder_pan, the `state` label,
+the `ballTrack` block, plus system telemetry). Import it as a custom
+template in /IOTCONNECT before creating the device.
+
+If you skip this section the demo still runs — it just prints `IoTConnect
+is unavailable; running without cloud connectivity` and proceeds with
+local-only operation.
+
+## 5. Calibrate the Ball
+
+> [!WARNING]
+> Both calibration scripts release **all six servo torques** so you can
+> free-pose the arm. **Always physically support the arm before pressing
+> Enter** — on a wall- or ceiling-mounted arm the whole assembly will swing
+> under gravity the instant torque drops.
+
+### Step 1 — Ball color *(required)*
+
+Captures HSV thresholds for ball segmentation. Writes `ball_color.json`.
+
+```
+cd ~/robotic-arm
+./calibrate.sh
+```
+
+Because the RZ/G3E has no display server (and we install
+`opencv-python-headless`), `calibrate.sh` defaults to the browser-based
+calibrator [`browser_calibrate.py`](browser_calibrate.py). On startup it
+prints a URL like:
+
+```
+[calib] HTTP listening on http://192.168.68.68:8000/
+```
+
+Open that URL from any laptop on the same LAN. The page shows a live
+MJPEG video feed from the wrist camera; **click directly on the ball** in
+the image to sample its HSV (each click samples a 7×7 patch). Hold the
+ball under your demo lighting and click 5–10 times — you'll see a green
+mask overlay grow to cover the ball as samples accumulate.
+
+Page controls:
+
+| Button             | What it does                                                                     |
+|--------------------|----------------------------------------------------------------------------------|
+| **Save & Quit**    | Writes `ball_color.json` and exits the script. Normal exit path. (green button) |
+| **Save**           | Writes the file but keeps the page open so you can keep adding samples and re-save. |
+| **Reset**          | Clears all samples (does not touch the on-disk file).                            |
+| **Hold pose**      | Re-engages torque at the current arm pose so you can let go.                     |
+| **Release torque** | Drops torque again so you can re-pose the camera.                                |
+| **Quit**           | Exits without saving (warns if you have unsaved samples).                        |
+
+`s` / `r` / `h` / `w` keystrokes work in the page as shortcuts.
+
+If you have a working display attached and want the original cv2-window
+calibrator instead, run `BROWSER=0 ./calibrate.sh` (uses
+[`ball_calibrate.py`](ball_calibrate.py) — note: this won't render
+because of `opencv-python-headless`).
+
+### Step 2 — Scan poses *(required if your arm mount differs from the upstream demo)*
+
+Captures the arm poses cycled through during `SCANNING`. Torque drops so
+you can pose the arm by hand. This script prints to the console; no
+browser needed.
+
+```
+./teach.sh
+```
+
+For each of `center` / `left edge` / `right edge`, pose the camera then
+press `s` + Enter to snapshot. The script prints a `SCAN_POSE = [...]`
+block ready to paste into [modes/ball_follow.py](modes/ball_follow.py).
+`h` + Enter re-enables torque, `q` + Enter quits.
+
+The poses pre-baked in [modes/ball_follow.py](modes/ball_follow.py:90)
+were captured for a wall/VESA-mounted arm looking down at a table. If
+your arm is on a benchtop base, recapture them.
+
+### Step 3 — Camera-gripper offset + grab radius *(run when you change ball/gripper/camera)*
+
+Reports three values you can paste into [modes/ball_follow.py](modes/ball_follow.py):
+
+- `CAM_GRIPPER_OFFSET_X` / `_Y` — pixel shift between the camera optical
+  axis and the gripper grab point. Leave at `0/0` for most builds.
+- `TARGET_RADIUS_PX` — the ball's apparent radius (in pixels) at the
+  height the gripper would normally grab from. **This is the value to
+  update when you swap to a different-sized ball.**
+
+```
+./calibrate_offset.sh
+```
+
+Like the color calibrator, this defaults to a browser version
+([`browser_calibrate_offset.py`](browser_calibrate_offset.py)) and prints
+a URL like `http://192.168.68.68:8000/`. Open it, **physically pose the
+gripper directly above the ball** at grab distance (use **Release torque**
+to free-pose, **Hold pose** to lock), then click **Snapshot**. The page
+displays a paste-ready block, e.g.:
+
+```
+CAM_GRIPPER_OFFSET_X = -3
+CAM_GRIPPER_OFFSET_Y = +12
+TARGET_RADIUS_PX     = 280
+# leave RADIUS_TOLERANCE roughly +/-20 for a safe margin
+```
+
+`BROWSER=0 ./calibrate_offset.sh` falls back to the cv2-window version.
+
+## 6. Run the Demo
+
+The recommended invocation on the RZ/G3E:
+
+```
+cd ~/robotic-arm
+./start.sh --headless --web-port 8000
+```
+
+`--mode ball` is the default. With the demo running, open
+`http://<board-ip>:8000/` from any laptop on the same LAN to watch the
+live camera feed with the ball-follow detection overlay (HSV mask, ball
+circle, pan/tilt/radius errors) and the current state-machine label
+(`SCANNING` → `TRACKING` → `GRABBING` → `HOLDING`).
+
+Other useful invocations:
+
+| Command                                              | When to use it                                          |
+|------------------------------------------------------|---------------------------------------------------------|
+| `./start.sh --headless --web-port 8000`              | **Recommended.** Live browser view, no display needed.  |
+| `./start.sh --headless`                              | Pure-headless run. Watch progress via `tail -f run.log` and /IOTCONNECT telemetry. |
+| `./start.sh --mode asl --headless --web-port 8000`   | Only if `torch` + `mediapipe` actually installed.       |
+| `./start.sh`                                         | Tries the cv2 preview window. Won't render on this image (opencv is headless). |
+
+All flags forwarded to `main.py`:
+
+| Flag                    | Purpose                                                                         |
+|-------------------------|---------------------------------------------------------------------------------|
+| `--mode {ball,asl}`     | Vision mode. Default `ball` (the supported mode on RZ/G3E).                     |
+| `--camera N`            | OpenCV camera index. Default `0` — the kernel exposes the USB UVC camera as `/dev/video0`. |
+| `--headless`            | Skip the cv2 preview window (use over SSH or when no monitor is attached).      |
+| `--web-port N`          | Serve the live annotated camera feed as MJPEG on port `N`. Pairs naturally with `--headless`. |
+| `--perf-every N`        | Print per-frame timing every N frames (default `30`).                           |
+
+> [!IMPORTANT]
+> Always make sure you are in the `~/robotic-arm` directory before launching —
+> the demo loads `iotcDeviceConfig.json`, `ball_color.json`, and (for `asl`
+> mode) `model/point_net_1.pth` from the current directory.
+
+A successful start looks like:
+
+```
+Connecting to XArm 1S...                              → Connected
+Connecting to IoTConnect...                           → Connected to IoTConnect successfully!
+Initializing to home position...                      → Home position reached!
+Starting vision mode: ball
+[INFO] Camera input: 0 (640, 480) — mode=ball headless=True
+[INFO] Live web view: http://192.168.68.68:8000/
+[ball] HSV range loaded: lower=[…] upper=[…]
+[ball] moving to scan pose [center]...
+[ball] SCAN[center]: no ball
+…
+```
+
+Drop the ball anywhere within the scan envelope and the arm will find it,
+approach, and grab. Open the gripper by hand (or via the `open_gripper`
+/IOTCONNECT command) to release and re-arm the cycle.
+
+## Mode availability
+
+| Mode    | Required on RZ/G3E                                               | Status |
+|---------|-------------------------------------------------------------------|--------|
+| `ball`  | `opencv-python-headless`, `numpy`, `xarm`, `hidapi`               | Fully supported — all wheels are available as prebuilt aarch64 manylinux wheels. |
+| `asl`   | `torch`, `torchvision`, `mediapipe` (in addition to `ball`'s deps) | Best-effort. These packages frequently lack `manylinux2014_aarch64` wheels for the CPython version shipped in the RZ/G3E image. If the install script reports `MISS: torch` or `MISS: mediapipe`, the `asl` mode will not start. |
+
+If you need ASL mode and the install script couldn't fetch the wheels, you
+have two options:
+
+1. **Build from source on the board** — slow (`torch` is a multi-hour build
+   on the RZ/G3E's Cortex-A55 cores) and may run out of memory; not
+   recommended without careful planning.
+2. **Use a custom Yocto image** that includes `meta-pytorch` /
+   `meta-tensorflow-lite` recipes, then re-run `deps-install.sh` to pick up
+   the remaining lighter deps. Out of scope for this guide.
+
+## Supported /IOTCONNECT commands
+
+These match the upstream TRIA demo and work in either mode (the arm responds
+even while a vision mode is running):
+
+- **Movement**: `move_forward`, `move_backward`, `move_left`, `move_right`,
+  `move_up`, `move_down`, `move_to_home`, `move_to` (with a 6-position payload)
+- **Wrist**: `wrist_roll_cw`, `wrist_roll_ccw`, `wrist_flex_up`, `wrist_flex_down`
+- **Gripper**: `open_gripper`, `close_gripper`
+- **Scripted demos**: `demo_wave`, `demo_bow`, `demo_stretch`, `demo_scan`,
+  `demo_shake_no`, `demo_pickup`
+
+## Telemetry
+
+Every payload carries a top-level `state` field identifying the active mode
+(`SCANNING`, `TRACKING`, `GRABBING`, `HOLDING`, etc. for ball mode;
+`ASL-Gesture` for ASL mode), the six servo positions, and a `sysInfo_*` block
+collected by [`systemdata.py`](systemdata.py). Ball mode additionally
+publishes a `ballTrack` block with detection / controller state — see the
+upstream demo's
+[telemetry section](https://github.com/avnet-iotconnect/iotc-tria-vision-ai-kit-robotic-arm#iotconnect-telemetry)
+for the full schema.
+
+> [!NOTE]
+> [`systemdata.py`](systemdata.py) was rewritten for this port to use only
+> stdlib + `/proc` and `/sys` reads. The TRIA build relied on `psutil` and
+> `py-cpuinfo`, but those packages import the `resource` and
+> `multiprocessing` stdlib modules — both of which are stripped from the
+> RZ/G3E's Yocto Python image. The RZ/G3E reports its CPU brand from
+> `/proc/device-tree/model` ("Renesas SMARC EVK based on r9a09g047e57"),
+> max CPU MHz from `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`,
+> and CPU temperature from the `cpu-thermal` zone. `gpu_temp`, `memory_temp`,
+> and `gpu_usage` are `0.0` on this board (no matching sysfs nodes).
+
+## Troubleshooting
+
+### Install / dependency errors
+
+- **`deps-install.sh` reports `MISS: cv2` (or numpy / hid) even though the
+  wheel installed.** Wheel ABI mismatch. The script downloaded `cp311`
+  wheels but your board runs Python 3.12 (or vice versa). Check
+  `python3 --version` on the board and re-run `deps-download.sh` with
+  `PY_VER=cp312` (or `cp311`, etc.) prepended. Then on the board, remove
+  the stale extracts before re-installing:
+  ```
+  SP=$(python3 -c "import sys; print([p for p in sys.path if 'site-packages' in p][0])")
+  rm -rf "$SP/cv2" "$SP/numpy" "$SP/numpy.libs" "$SP"/hid*.so
+  rm -f ~/*.whl
+  ```
+  Then re-run `deps-download.sh` from the host and `deps-install.sh` on
+  the board.
+
+- **`ModuleNotFoundError: No module named 'resource'` / `'multiprocessing'`
+  / `'statistics'`.** The Yocto image strips these stdlib modules. The
+  demo source has been written to avoid them, but if you see this from a
+  Python package you've added (e.g. `psutil`, `py-cpuinfo`), that
+  package won't work on this image.
+
+- **`stdbuf: not found`.** The busybox image doesn't ship `stdbuf`. The
+  bundled [`start.sh`](start.sh) does not use it — if you see this, you
+  may have an outdated copy. Re-pull from the repo.
+
+### Runtime errors
+
+- **`xarm.Controller('USB')` fails to open.** Confirm the arm is powered
+  and present:
+  ```
+  lsusb | grep 0483:5750
+  ```
+  (lsusb's database labels this VID:PID as "STMicroelectronics LED badge"
+  — that's normal; the xArm shares the ST HID chip.)
+
+- **Camera not opening / `[ERROR] Camera failed to open!`.**
+  ```
+  ls /dev/video*
+  v4l2-ctl --list-devices
+  ```
+  The USB UVC camera is normally `/dev/video0`. The demo defaults to
+  index `0`; pass `--camera 1` etc. if your kernel enumerated it
+  differently.
+
+- **`ball_color.json not found`.** Run `./calibrate.sh` first; both
+  ball-follow and the offset calibrator depend on it.
+
+- **`asl` mode raises `ModuleNotFoundError: No module named 'torch'`.**
+  The ML wheels aren't installed (see [Mode availability](#mode-availability)).
+  Use `--mode ball` instead.
+
+- **Browser shows the page but the live MJPEG stays blank.** Camera
+  thread couldn't open `/dev/video0`. Look at the calibrator's stdout
+  on the board for `ERROR: could not open camera`. Common cause:
+  another instance of the calibrator (or `main.py`) is still holding
+  the device — `pgrep -af python` and `kill` it.
+
+### USB / hardware
+
+- **`xhci-renesas-hcd … reset high-speed USB device`** in dmesg, or
+  `Event TRB for slot N ep N with no TDs queued` warnings. Cosmetic
+  — these fire when V4L2 closes a capture handle while the XHCI
+  controller still has buffers queued. The camera reattaches and the
+  demo keeps running.
+
+- **Camera or arm intermittently disappears from `lsusb`.** USB-power
+  starvation. The Brio 100 + arm together can pull more than a single
+  bus-powered USB-C port wants to deliver. Use a **powered** USB hub
+  between the board and the camera.
+
+- **Both HDMI ports show `disconnected` even with a monitor plugged
+  in.** The shipped Yocto image doesn't bring up Weston, and the
+  ADV7535 (carrier board HDMI) / IT6263 (LVDS-to-HDMI add-on) bridges
+  may not assert HPD without a compositor. **You don't need a monitor
+  for this demo** — operate everything via SSH + browser. If you
+  really want a display, expect to install a Wayland compositor and
+  swap `opencv-python-headless` for full `opencv-python` plus a Qt
+  backend.
+
+For everything mode-specific (ball-mode tuning constants, gripper stall
+detection, scan-envelope tuning, etc.), the upstream demo's
+[README](https://github.com/avnet-iotconnect/iotc-tria-vision-ai-kit-robotic-arm#readme)
+remains the authoritative reference — the per-mode source code in
+[`modes/`](modes/) is identical to the TRIA build.

--- a/renesas-rzg3e-evk/robotic-arm/ball_calibrate.py
+++ b/renesas-rzg3e-evk/robotic-arm/ball_calibrate.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Ball-color HSV calibrator.
+
+Opens the wrist camera, lets you click on the ball repeatedly. Each click
+samples a small patch and expands a running HSV min/max box. A live mask
+preview shows what the ball-follow mode will see. Save with 's', reset with
+'r', quit (without saving) with 'q' or ESC.
+
+Camera-angle helper: at startup the script prompts before releasing ALL servo
+torque so you can free-pose the entire arm to point the camera at where the
+ball will sit. SUPPORT THE ARM before pressing Enter — it will swing under
+gravity. Press 'h' in the window to re-engage all torque at the current pose,
+'w' to release everything again.
+
+Typical use: hold the ball in different parts of the frame / under the
+lighting you'll demo in, click 5-10 times, then 's'.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import cv2
+import numpy as np
+import xarm
+
+OUT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ball_color.json")
+PATCH_RADIUS = 3      # 7x7 sample patch around each click
+HUE_PAD = 8           # extra hue tolerance on each side
+SAT_PAD = 25
+VAL_PAD = 25
+
+ALL_SERVO_IDS = [1, 2, 3, 4, 5, 6]  # gripper, wrist_roll, wrist_flex, elbow_flex, shoulder_lift, shoulder_pan
+
+samples = []          # list of (h, s, v) median values, one per click
+hsv_frame = None      # latest HSV frame, set in main loop
+
+
+def on_mouse(event, x, y, flags, param):
+    if event != cv2.EVENT_LBUTTONDOWN or hsv_frame is None:
+        return
+    h, w = hsv_frame.shape[:2]
+    x0, x1 = max(0, x - PATCH_RADIUS), min(w, x + PATCH_RADIUS + 1)
+    y0, y1 = max(0, y - PATCH_RADIUS), min(h, y + PATCH_RADIUS + 1)
+    patch = hsv_frame[y0:y1, x0:x1].reshape(-1, 3)
+    med = np.median(patch, axis=0).astype(int)
+    samples.append(tuple(med.tolist()))
+    print(f"click @({x},{y}) -> H={med[0]} S={med[1]} V={med[2]}  (samples: {len(samples)})")
+
+
+def current_range():
+    """Return (lower, upper) HSV bounds, padded. None if no samples yet."""
+    if not samples:
+        return None
+    arr = np.array(samples)
+    h_lo, h_hi = arr[:, 0].min() - HUE_PAD, arr[:, 0].max() + HUE_PAD
+    s_lo, s_hi = arr[:, 1].min() - SAT_PAD, arr[:, 1].max() + SAT_PAD
+    v_lo, v_hi = arr[:, 2].min() - VAL_PAD, arr[:, 2].max() + VAL_PAD
+    lower = np.array([max(0, h_lo), max(0, s_lo), max(0, v_lo)], dtype=np.uint8)
+    upper = np.array([min(180, h_hi), min(255, s_hi), min(255, v_hi)], dtype=np.uint8)
+    return lower, upper
+
+
+def release_all(arm):
+    try:
+        arm.servoOff()
+        print("[calib] ALL torque OFF — pose the arm by hand.")
+    except Exception as e:
+        print(f"[calib] servoOff failed: {e}")
+
+
+def hold_all(arm):
+    try:
+        targets = [[sid, int(arm.getPosition(sid))] for sid in ALL_SERVO_IDS]
+        arm.setPosition(targets, duration=1500, wait=True)
+        print("[calib] torque ON at current pose.")
+    except Exception as e:
+        print(f"[calib] hold failed: {e}")
+
+
+def save_range(lower, upper, camera_index):
+    payload = {
+        "camera_index": int(camera_index),
+        "h_min": int(lower[0]), "h_max": int(upper[0]),
+        "s_min": int(lower[1]), "s_max": int(upper[1]),
+        "v_min": int(lower[2]), "v_max": int(upper[2]),
+        "samples": [list(s) for s in samples],
+    }
+    with open(OUT_PATH, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"\nSaved {len(samples)} samples to {OUT_PATH}")
+    print(f"  HSV lower: {lower.tolist()}")
+    print(f"  HSV upper: {upper.tolist()}")
+
+
+def main():
+    global hsv_frame
+    parser = argparse.ArgumentParser(description="HSV ball-color calibrator")
+    parser.add_argument("--camera", type=int, default=2, help="OpenCV camera index (default 2)")
+    parser.add_argument("--width", type=int, default=640)
+    parser.add_argument("--height", type=int, default=480)
+    args = parser.parse_args()
+
+    print("[calib] connecting to xArm...")
+    arm = xarm.Controller('USB')
+
+    print("\n" + "=" * 60)
+    print(" SAFETY: ALL torque is about to drop. Support the arm with your")
+    print(" hand before pressing Enter, or it will swing under gravity.")
+    print("=" * 60)
+    input("[calib] Holding the arm? Press Enter to release torque... ")
+    release_all(arm)
+
+    cap = cv2.VideoCapture(args.camera)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, args.width)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, args.height)
+    if not cap.isOpened():
+        print(f"ERROR: could not open camera {args.camera}", file=sys.stderr)
+        hold_all(arm)
+        return 1
+
+    win = "Ball Calibrator"
+    cv2.namedWindow(win)
+    cv2.setMouseCallback(win, on_mouse)
+
+    print("Click the ball in the live view. 's' save, 'r' reset, 'h' hold pose (torque on), 'w' release torque, 'q'/ESC quit.")
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            print("[ERROR] camera read failed", file=sys.stderr)
+            break
+        hsv_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+
+        rng = current_range()
+        if rng is not None:
+            lower, upper = rng
+            mask = cv2.inRange(hsv_frame, lower, upper)
+            mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((5, 5), np.uint8))
+            overlay = frame.copy()
+            overlay[mask > 0] = (0, 255, 0)
+            display = cv2.addWeighted(frame, 0.6, overlay, 0.4, 0)
+            cv2.putText(display, f"samples={len(samples)} H[{lower[0]}-{upper[0]}] S[{lower[1]}-{upper[1]}] V[{lower[2]}-{upper[2]}]",
+                        (10, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2, cv2.LINE_AA)
+        else:
+            display = frame.copy()
+            cv2.putText(display, "click the ball...", (10, 25),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 255), 2, cv2.LINE_AA)
+
+        cv2.imshow(win, display)
+        key = cv2.waitKey(10) & 0xFF
+        if key in (27, ord('q')):
+            print("Quit without saving.")
+            break
+        if key == ord('r'):
+            samples.clear()
+            print("Reset samples.")
+        if key == ord('h'):
+            hold_all(arm)
+        if key == ord('w'):
+            release_all(arm)
+        if key == ord('s'):
+            if rng is None:
+                print("Nothing to save yet — click the ball first.")
+                continue
+            save_range(rng[0], rng[1], args.camera)
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+    hold_all(arm)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/renesas-rzg3e-evk/robotic-arm/browser_calibrate.py
+++ b/renesas-rzg3e-evk/robotic-arm/browser_calibrate.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Browser-based ball-color HSV calibrator.
+
+Same output as ball_calibrate.py (writes ball_color.json), but the live
+preview is served as MJPEG over HTTP and clicks come from a web page,
+not a cv2 window. Built for the RZ/G3E where there's no display server
+and we use opencv-python-headless (no cv2.imshow).
+
+Open http://<board-ip>:8000/ in any browser on the same LAN, click the
+ball, hit "Save".
+
+Camera-angle helper: at startup the script prompts before releasing all
+servo torque so you can free-pose the arm. SUPPORT THE ARM before
+pressing Enter — it will swing under gravity. Use the "Hold pose" /
+"Release torque" buttons in the page to re-engage / drop torque after
+that.
+"""
+
+import argparse
+import io
+import json
+import os
+import socket
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+import cv2
+import numpy as np
+import xarm
+
+OUT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ball_color.json")
+PATCH_RADIUS = 3      # 7x7 sample patch around each click
+HUE_PAD = 8
+SAT_PAD = 25
+VAL_PAD = 25
+ALL_SERVO_IDS = [1, 2, 3, 4, 5, 6]
+
+
+# ---------------------------- shared state ----------------------------
+
+class State:
+    """Thread-safe container for everything the camera thread produces and
+    the HTTP handlers consume / mutate."""
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.frame_jpeg = b""             # most recent annotated JPEG
+        self.frame_w = 0
+        self.frame_h = 0
+        self.hsv = None                   # raw HSV frame for click sampling
+        self.samples = []                 # list of (h, s, v) median tuples
+        self.saved_at = None              # set by /save
+        self.quit = False                 # set when user clicks Quit
+
+
+def current_range(samples):
+    if not samples:
+        return None
+    arr = np.array(samples)
+    h_lo, h_hi = arr[:, 0].min() - HUE_PAD, arr[:, 0].max() + HUE_PAD
+    s_lo, s_hi = arr[:, 1].min() - SAT_PAD, arr[:, 1].max() + SAT_PAD
+    v_lo, v_hi = arr[:, 2].min() - VAL_PAD, arr[:, 2].max() + VAL_PAD
+    lower = np.array([max(0, h_lo), max(0, s_lo), max(0, v_lo)], dtype=np.uint8)
+    upper = np.array([min(180, h_hi), min(255, s_hi), min(255, v_hi)], dtype=np.uint8)
+    return lower, upper
+
+
+# ---------------------------- camera worker ---------------------------
+
+def camera_loop(state, camera_index, width, height, jpeg_quality=80):
+    """Continuously read camera frames, build the annotated overlay, and
+    publish the JPEG-encoded frame to State for any active MJPEG client."""
+    cap = cv2.VideoCapture(camera_index)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+    cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)
+    if not cap.isOpened():
+        print(f"[calib] ERROR: could not open camera {camera_index}", file=sys.stderr)
+        state.quit = True
+        return
+
+    print(f"[calib] camera {camera_index} opened ({width}x{height})")
+    enc_params = [int(cv2.IMWRITE_JPEG_QUALITY), jpeg_quality]
+
+    try:
+        while not state.quit:
+            ok, frame = cap.read()
+            if not ok:
+                time.sleep(0.01)
+                continue
+
+            hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+            with state.lock:
+                samples_snapshot = list(state.samples)
+
+            rng = current_range(samples_snapshot)
+            if rng is not None:
+                lower, upper = rng
+                mask = cv2.inRange(hsv, lower, upper)
+                mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((5, 5), np.uint8))
+                overlay = frame.copy()
+                overlay[mask > 0] = (0, 255, 0)
+                display = cv2.addWeighted(frame, 0.6, overlay, 0.4, 0)
+                label = (f"samples={len(samples_snapshot)} "
+                         f"H[{lower[0]}-{upper[0]}] S[{lower[1]}-{upper[1]}] V[{lower[2]}-{upper[2]}]")
+            else:
+                display = frame.copy()
+                label = "click the ball..."
+            cv2.putText(display, label, (10, 25),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2, cv2.LINE_AA)
+
+            ok, buf = cv2.imencode(".jpg", display, enc_params)
+            if not ok:
+                continue
+            jpeg = buf.tobytes()
+            h, w = display.shape[:2]
+            with state.lock:
+                state.frame_jpeg = jpeg
+                state.hsv = hsv
+                state.frame_w = w
+                state.frame_h = h
+    finally:
+        cap.release()
+        print("[calib] camera released")
+
+
+# ---------------------------- HTTP handlers ---------------------------
+
+INDEX_HTML = """<!doctype html>
+<html><head><meta charset="utf-8"><title>Ball Calibrator</title>
+<style>
+  body { font: 14px sans-serif; margin: 1em; background: #111; color: #eee; }
+  #wrap { display: flex; gap: 1em; flex-wrap: wrap; }
+  #stream { display: block; cursor: crosshair; max-width: 100%; }
+  #panel { min-width: 280px; }
+  button { margin: 0.2em 0.4em 0.2em 0; padding: 0.5em 0.9em; font-size: 14px; cursor: pointer; }
+  pre { background: #222; padding: 0.6em; border-radius: 4px; max-height: 300px; overflow: auto; }
+  .sav { color: #6f6; }
+  .err { color: #f66; }
+</style></head>
+<body>
+<h2>Ball-color HSV calibrator (RZ/G3E)</h2>
+<div id="wrap">
+  <div>
+    <img id="stream" src="/stream" alt="(camera stream)">
+    <p>Click the ball in the image. Each click samples a 7x7 HSV patch.</p>
+  </div>
+  <div id="panel">
+    <div>
+      <button id="savequit" style="background:#2a7;color:white;font-weight:bold;">Save &amp; Quit</button>
+      <button id="save">Save (s)</button>
+      <button id="reset">Reset (r)</button>
+      <button id="hold">Hold pose (h)</button>
+      <button id="release">Release torque (w)</button>
+      <button id="quit">Quit</button>
+    </div>
+    <p id="status">samples: 0</p>
+    <pre id="log">(no clicks yet)</pre>
+  </div>
+</div>
+<script>
+const img = document.getElementById('stream');
+const status = document.getElementById('status');
+const log = document.getElementById('log');
+
+img.addEventListener('click', async (ev) => {
+  const r = img.getBoundingClientRect();
+  // Convert displayed-pixel click into the natural image coordinate.
+  const sx = img.naturalWidth / r.width;
+  const sy = img.naturalHeight / r.height;
+  const x = Math.round((ev.clientX - r.left) * sx);
+  const y = Math.round((ev.clientY - r.top) * sy);
+  const res = await fetch('/click', {method: 'POST', body: JSON.stringify({x, y})});
+  const data = await res.json();
+  // A new sample makes the on-disk file stale.
+  saved = false;
+  refresh(data);
+});
+
+async function action(path) {
+  const res = await fetch(path, {method: 'POST'});
+  const data = await res.json();
+  // Reset clears in-memory samples — the on-disk file (if any) is now stale.
+  if (path === '/reset') saved = false;
+  refresh(data);
+  if (data.message) log.textContent = data.message + '\\n' + log.textContent;
+}
+
+// Tracks whether the most recently sampled state has been written to disk.
+// Cleared on /reset and on every new click (since a new sample makes the
+// on-disk file stale relative to current samples).
+let saved = false;
+
+async function saveAndQuit() {
+  const r = await fetch('/save', {method: 'POST'});
+  const d = await r.json();
+  refresh(d);
+  if (d.saved) action('/quit');
+}
+
+document.getElementById('savequit').onclick = saveAndQuit;
+document.getElementById('save').onclick    = () => action('/save');
+document.getElementById('reset').onclick   = () => action('/reset');
+document.getElementById('hold').onclick    = () => action('/hold');
+document.getElementById('release').onclick = () => action('/release');
+document.getElementById('quit').onclick    = () => {
+  const msg = saved ? 'Quit?' : 'You have unsaved samples. Quit anyway?';
+  if (confirm(msg)) action('/quit');
+};
+
+document.addEventListener('keydown', (ev) => {
+  if (ev.target.tagName === 'INPUT') return;
+  if (ev.key === 's') action('/save');
+  if (ev.key === 'r') action('/reset');
+  if (ev.key === 'h') action('/hold');
+  if (ev.key === 'w') action('/release');
+});
+
+function refresh(data) {
+  if (!data) return;
+  let s = `samples: ${data.count}`;
+  if (data.range) s += `  HSV [${data.range.lower}] - [${data.range.upper}]`;
+  if (data.saved) {
+    s += `  <span class="sav">SAVED -> ${data.saved}</span>`;
+    saved = true;
+  }
+  status.innerHTML = s;
+  if (data.samples_log) log.textContent = data.samples_log;
+}
+
+// Poll status every second so external state changes (CLI quit, errors) are visible.
+setInterval(async () => {
+  try { refresh(await (await fetch('/state')).json()); } catch(e) {}
+}, 1000);
+</script>
+</body></html>
+"""
+
+
+def _sample_at(state, x, y):
+    """Sample a 7x7 HSV patch around (x, y) and append the median to samples."""
+    with state.lock:
+        if state.hsv is None:
+            return None
+        h, w = state.hsv.shape[:2]
+        if not (0 <= x < w and 0 <= y < h):
+            return None
+        x0, x1 = max(0, x - PATCH_RADIUS), min(w, x + PATCH_RADIUS + 1)
+        y0, y1 = max(0, y - PATCH_RADIUS), min(h, y + PATCH_RADIUS + 1)
+        patch = state.hsv[y0:y1, x0:x1].reshape(-1, 3)
+        med = np.median(patch, axis=0).astype(int)
+        sample = tuple(int(v) for v in med.tolist())
+        state.samples.append(sample)
+        return sample
+
+
+def _state_payload(state, message=None, saved=None):
+    with state.lock:
+        samples = list(state.samples)
+    rng = current_range(samples)
+    payload = {"count": len(samples)}
+    if rng is not None:
+        lo, hi = rng
+        payload["range"] = {"lower": lo.tolist(), "upper": hi.tolist()}
+    if message is not None:
+        payload["message"] = message
+    if saved is not None:
+        payload["saved"] = saved
+    payload["samples_log"] = "\n".join(
+        f"#{i + 1}: H={s[0]} S={s[1]} V={s[2]}" for i, s in enumerate(samples)
+    ) or "(no clicks yet)"
+    return payload
+
+
+def make_handler(state, arm, camera_index):
+
+    class Handler(BaseHTTPRequestHandler):
+        # Quiet the default access log — too noisy for an MJPEG stream.
+        def log_message(self, fmt, *args):
+            return
+
+        def _json(self, payload, code=200):
+            body = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            url = urlparse(self.path)
+            if url.path in ("/", "/index.html"):
+                body = INDEX_HTML.encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+
+            if url.path == "/state":
+                self._json(_state_payload(state))
+                return
+
+            if url.path == "/stream":
+                self.send_response(200)
+                self.send_header("Content-Type",
+                                 "multipart/x-mixed-replace; boundary=FRAME")
+                self.send_header("Cache-Control", "no-cache, private")
+                self.send_header("Pragma", "no-cache")
+                self.end_headers()
+                try:
+                    last = None
+                    while not state.quit:
+                        with state.lock:
+                            buf = state.frame_jpeg
+                        if buf and buf is not last:
+                            self.wfile.write(b"--FRAME\r\n")
+                            self.wfile.write(b"Content-Type: image/jpeg\r\n")
+                            self.wfile.write(
+                                f"Content-Length: {len(buf)}\r\n\r\n".encode())
+                            self.wfile.write(buf)
+                            self.wfile.write(b"\r\n")
+                            last = buf
+                        time.sleep(0.05)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+                return
+
+            self.send_response(404)
+            self.end_headers()
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0) or 0)
+            raw = self.rfile.read(length) if length else b""
+
+            if self.path == "/click":
+                try:
+                    data = json.loads(raw or b"{}")
+                    x = int(data.get("x"))
+                    y = int(data.get("y"))
+                except (ValueError, TypeError):
+                    self._json({"error": "bad coords"}, code=400)
+                    return
+                sample = _sample_at(state, x, y)
+                msg = (f"click @({x},{y}) -> H={sample[0]} S={sample[1]} V={sample[2]}"
+                       if sample else f"click @({x},{y}) -> out of bounds")
+                print(f"[calib] {msg}")
+                self._json(_state_payload(state, message=msg))
+                return
+
+            if self.path == "/reset":
+                with state.lock:
+                    state.samples.clear()
+                print("[calib] samples reset")
+                self._json(_state_payload(state, message="samples reset"))
+                return
+
+            if self.path == "/save":
+                with state.lock:
+                    samples_copy = list(state.samples)
+                rng = current_range(samples_copy)
+                if rng is None:
+                    self._json(_state_payload(
+                        state, message="nothing to save — click the ball first"))
+                    return
+                lower, upper = rng
+                payload = {
+                    "camera_index": int(camera_index),
+                    "h_min": int(lower[0]), "h_max": int(upper[0]),
+                    "s_min": int(lower[1]), "s_max": int(upper[1]),
+                    "v_min": int(lower[2]), "v_max": int(upper[2]),
+                    "samples": [list(s) for s in samples_copy],
+                }
+                with open(OUT_PATH, "w") as f:
+                    json.dump(payload, f, indent=2)
+                print(f"[calib] SAVED {len(samples_copy)} samples to {OUT_PATH}")
+                print(f"  HSV lower: {lower.tolist()}")
+                print(f"  HSV upper: {upper.tolist()}")
+                self._json(_state_payload(
+                    state, message=f"saved {len(samples_copy)} samples", saved=OUT_PATH))
+                return
+
+            if self.path == "/hold":
+                try:
+                    targets = [[sid, int(arm.getPosition(sid))] for sid in ALL_SERVO_IDS]
+                    arm.setPosition(targets, duration=1500, wait=True)
+                    msg = "torque ON at current pose"
+                except Exception as e:
+                    msg = f"hold failed: {e}"
+                print(f"[calib] {msg}")
+                self._json(_state_payload(state, message=msg))
+                return
+
+            if self.path == "/release":
+                try:
+                    arm.servoOff()
+                    msg = "ALL torque OFF — pose the arm by hand"
+                except Exception as e:
+                    msg = f"release failed: {e}"
+                print(f"[calib] {msg}")
+                self._json(_state_payload(state, message=msg))
+                return
+
+            if self.path == "/quit":
+                state.quit = True
+                self._json(_state_payload(state, message="exiting"))
+                return
+
+            self.send_response(404)
+            self.end_headers()
+
+    return Handler
+
+
+def _local_ip_hint():
+    """Best-effort guess at the LAN IP to print in the URL hint."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except OSError:
+        return "0.0.0.0"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Browser HSV ball-color calibrator")
+    parser.add_argument("--camera", type=int, default=0,
+                        help="OpenCV camera index (default 0 — RZ/G3E /dev/video0)")
+    parser.add_argument("--width", type=int, default=640)
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--port", type=int, default=8000, help="HTTP listen port")
+    parser.add_argument("--no-arm", action="store_true",
+                        help="Skip xArm connection (camera-only test mode)")
+    args = parser.parse_args()
+
+    arm = None
+    if not args.no_arm:
+        print("[calib] connecting to xArm...")
+        arm = xarm.Controller("USB")
+        print("\n" + "=" * 60)
+        print(" SAFETY: ALL torque is about to drop. Support the arm with your")
+        print(" hand before pressing Enter, or it will swing under gravity.")
+        print("=" * 60)
+        input("[calib] Holding the arm? Press Enter to release torque... ")
+        try:
+            arm.servoOff()
+            print("[calib] ALL torque OFF — pose the arm by hand.")
+        except Exception as e:
+            print(f"[calib] servoOff failed: {e}")
+    else:
+        print("[calib] --no-arm: running camera-only (no torque control)")
+
+    state = State()
+    cam_thread = threading.Thread(
+        target=camera_loop,
+        args=(state, args.camera, args.width, args.height),
+        daemon=True,
+    )
+    cam_thread.start()
+
+    handler = make_handler(state, arm, args.camera)
+    server = ThreadingHTTPServer(("0.0.0.0", args.port), handler)
+    print(f"\n[calib] HTTP listening on http://{_local_ip_hint()}:{args.port}/  (Ctrl-C to quit)")
+
+    try:
+        while not state.quit:
+            server.handle_request()
+    except KeyboardInterrupt:
+        print("\n[calib] interrupted")
+    finally:
+        state.quit = True
+        cam_thread.join(timeout=2.0)
+        if arm is not None:
+            try:
+                targets = [[sid, int(arm.getPosition(sid))] for sid in ALL_SERVO_IDS]
+                arm.setPosition(targets, duration=1500, wait=True)
+                print("[calib] re-engaged torque at current pose on exit")
+            except Exception as e:
+                print(f"[calib] final hold failed: {e}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/renesas-rzg3e-evk/robotic-arm/browser_calibrate_offset.py
+++ b/renesas-rzg3e-evk/robotic-arm/browser_calibrate_offset.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Browser-based camera-gripper offset + grab-radius calibrator.
+
+Same job as calibrate_cam_offset.py but rendered as MJPEG + a small HTML
+page so it works on the RZ/G3E (no display server, opencv-python-headless).
+Workflow:
+
+  1. SUPPORT THE ARM — all torque drops on launch.
+  2. Open http://<board-ip>:<port>/ in a browser.
+  3. Pose the gripper directly over the ball at the height it would normally
+     grab from. The live overlay shows the detected ball, its (bx, by, r),
+     and the resulting OFFSET_X / OFFSET_Y.
+  4. Hold steady, click "Snapshot". The script averages the last ~30 frames
+     and prints recommended values for:
+        CAM_GRIPPER_OFFSET_X
+        CAM_GRIPPER_OFFSET_Y
+        TARGET_RADIUS_PX        <-- the ball's apparent radius at grab dist
+     Paste these into modes/ball_follow.py.
+  5. "Hold pose" re-engages torque. "Release torque" drops it again.
+"""
+
+import argparse
+import json
+import os
+import socket
+import sys
+import threading
+import time
+from collections import deque
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import cv2
+import numpy as np
+import xarm
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HSV_PATH = os.path.join(HERE, "ball_color.json")
+
+# Match ball_follow.py detection params so what we measure matches what it sees.
+MIN_CONTOUR_AREA = 200
+MIN_FILL_RATIO = 0.65
+SAMPLE_WINDOW = 30
+ALL_SERVO_IDS = [1, 2, 3, 4, 5, 6]
+
+
+def _median(values):
+    s = sorted(values)
+    n = len(s)
+    if n == 0:
+        raise ValueError("median of empty sequence")
+    mid = n // 2
+    return s[mid] if n % 2 else (s[mid - 1] + s[mid]) / 2
+
+
+def _pstdev(values):
+    n = len(values)
+    if n == 0:
+        return 0.0
+    mean = sum(values) / n
+    return (sum((v - mean) ** 2 for v in values) / n) ** 0.5
+
+
+def largest_blob(mask):
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    best = None
+    best_area = 0
+    for c in contours:
+        area = cv2.contourArea(c)
+        if area < MIN_CONTOUR_AREA or area <= best_area:
+            continue
+        (x, y), r = cv2.minEnclosingCircle(c)
+        if r <= 0:
+            continue
+        if area / (np.pi * r * r) < MIN_FILL_RATIO:
+            continue
+        best = (int(x), int(y), float(r))
+        best_area = area
+    return best
+
+
+# ---------------------------- shared state ----------------------------
+
+class State:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.frame_jpeg = b""
+        self.frame_w = 0
+        self.frame_h = 0
+        self.bx = self.by = self.br = None      # latest detection
+        self.recent = deque(maxlen=SAMPLE_WINDOW)  # (bx, by, br)
+        self.last_snapshot = None               # dict shown on the page
+        self.quit = False
+
+
+# ---------------------------- camera loop -----------------------------
+
+def camera_loop(state, camera_index, width, height, lower, upper, jpeg_quality=80):
+    cap = cv2.VideoCapture(camera_index)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+    cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)
+    if not cap.isOpened():
+        print(f"[calib] ERROR: could not open camera {camera_index}", file=sys.stderr)
+        state.quit = True
+        return
+    print(f"[calib] camera {camera_index} opened ({width}x{height})")
+    enc_params = [int(cv2.IMWRITE_JPEG_QUALITY), jpeg_quality]
+
+    try:
+        while not state.quit:
+            ok, frame = cap.read()
+            if not ok:
+                time.sleep(0.01)
+                continue
+            h, w = frame.shape[:2]
+
+            hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+            mask = cv2.inRange(hsv, lower, upper)
+            mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((5, 5), np.uint8))
+            mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((9, 9), np.uint8))
+
+            ball = largest_blob(mask)
+
+            # Annotate. Mirror horizontally so what the user sees matches
+            # how ball_follow displays the wrist camera.
+            annotated = cv2.flip(frame, 1)
+            cx, cy = w // 2, h // 2
+            cv2.drawMarker(annotated, (cx, cy), (255, 255, 255),
+                           markerType=cv2.MARKER_CROSS, markerSize=20, thickness=1)
+
+            with state.lock:
+                state.frame_w, state.frame_h = w, h
+                if ball is not None:
+                    bx, by, br = ball
+                    state.bx, state.by, state.br = bx, by, br
+                    state.recent.append((bx, by, br))
+                    dx = bx - cx
+                    dy = by - cy
+                    bx_disp = w - bx
+                    cv2.circle(annotated, (bx_disp, by), int(br), (0, 255, 0), 2)
+                    cv2.circle(annotated, (bx_disp, by), 4, (0, 255, 0), -1)
+                    cv2.putText(annotated, f"bx={bx} by={by} r={int(br)}",
+                                (10, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.55,
+                                (0, 255, 0), 2, cv2.LINE_AA)
+                    cv2.putText(annotated,
+                                f"OFFSET_X={dx:+d}  OFFSET_Y={dy:+d}",
+                                (10, 50), cv2.FONT_HERSHEY_SIMPLEX, 0.6,
+                                (0, 255, 255), 2, cv2.LINE_AA)
+                    cv2.putText(annotated,
+                                f"samples={len(state.recent)}/{SAMPLE_WINDOW}",
+                                (10, 75), cv2.FONT_HERSHEY_SIMPLEX, 0.5,
+                                (200, 200, 200), 1, cv2.LINE_AA)
+                else:
+                    state.bx = state.by = state.br = None
+                    cv2.putText(annotated, "no ball detected", (10, 25),
+                                cv2.FONT_HERSHEY_SIMPLEX, 0.6,
+                                (0, 0, 255), 2, cv2.LINE_AA)
+
+                ok2, buf = cv2.imencode(".jpg", annotated, enc_params)
+                if ok2:
+                    state.frame_jpeg = buf.tobytes()
+    finally:
+        cap.release()
+        print("[calib] camera released")
+
+
+# ---------------------------- HTTP plumbing ---------------------------
+
+INDEX_HTML = """<!doctype html>
+<html><head><meta charset="utf-8"><title>Cam-Gripper Offset Calibrator</title>
+<style>
+  body { font: 14px sans-serif; margin: 1em; background: #111; color: #eee; }
+  #wrap { display: flex; gap: 1em; flex-wrap: wrap; }
+  #stream { display: block; max-width: 100%; }
+  #panel { min-width: 320px; }
+  button { margin: 0.2em 0.4em 0.2em 0; padding: 0.5em 0.9em; font-size: 14px; cursor: pointer; }
+  pre { background: #222; padding: 0.6em; border-radius: 4px; max-height: 360px; overflow: auto; white-space: pre-wrap; }
+  .hi { color: #6cf; }
+</style></head>
+<body>
+<h2>Camera-gripper offset + grab-radius calibrator</h2>
+<div id="wrap">
+  <div>
+    <img id="stream" src="/stream" alt="(camera stream)">
+    <p>Pose the gripper directly above the ball at the height it would normally grab from. Hold steady, click <b>Snapshot</b>.</p>
+  </div>
+  <div id="panel">
+    <div>
+      <button id="snap">Snapshot (s)</button>
+      <button id="hold">Hold pose (h)</button>
+      <button id="release">Release torque (r)</button>
+      <button id="quit">Quit</button>
+    </div>
+    <p id="status">live: (no ball)</p>
+    <pre id="result">(no snapshot yet)</pre>
+  </div>
+</div>
+<script>
+const status = document.getElementById('status');
+const result = document.getElementById('result');
+
+async function action(path) {
+  const r = await fetch(path, {method: 'POST'});
+  const d = await r.json();
+  refresh(d);
+}
+document.getElementById('snap').onclick    = () => action('/snapshot');
+document.getElementById('hold').onclick    = () => action('/hold');
+document.getElementById('release').onclick = () => action('/release');
+document.getElementById('quit').onclick    = () => { if (confirm('Quit?')) action('/quit'); };
+
+document.addEventListener('keydown', (ev) => {
+  if (ev.target.tagName === 'INPUT') return;
+  if (ev.key === 's') action('/snapshot');
+  if (ev.key === 'h') action('/hold');
+  if (ev.key === 'r') action('/release');
+});
+
+function refresh(data) {
+  if (!data) return;
+  if (data.live) {
+    if (data.live.bx === null) {
+      status.textContent = `live: no ball  (samples ${data.live.samples}/${data.live.sample_window})`;
+    } else {
+      status.textContent = `live: bx=${data.live.bx} by=${data.live.by} r=${data.live.br}`
+        + `  OFFSET_X=${data.live.off_x>=0?'+':''}${data.live.off_x}`
+        + `  OFFSET_Y=${data.live.off_y>=0?'+':''}${data.live.off_y}`
+        + `  (samples ${data.live.samples}/${data.live.sample_window})`;
+    }
+  }
+  if (data.snapshot) result.textContent = data.snapshot;
+  if (data.message) result.textContent = data.message + '\\n\\n' + result.textContent;
+}
+
+setInterval(async () => {
+  try { refresh(await (await fetch('/state')).json()); } catch(e) {}
+}, 500);
+</script>
+</body></html>
+"""
+
+
+def _live_view(state):
+    with state.lock:
+        bx, by, br = state.bx, state.by, state.br
+        w, h = state.frame_w, state.frame_h
+        n = len(state.recent)
+    if not w or not h:
+        return None
+    cx, cy = w // 2, h // 2
+    if bx is None:
+        return {"bx": None, "by": None, "br": None,
+                "off_x": 0, "off_y": 0,
+                "samples": n, "sample_window": SAMPLE_WINDOW}
+    return {"bx": int(bx), "by": int(by), "br": int(br),
+            "off_x": int(bx - cx), "off_y": int(by - cy),
+            "samples": n, "sample_window": SAMPLE_WINDOW}
+
+
+def _state_payload(state, message=None, snapshot_text=None):
+    payload = {"live": _live_view(state)}
+    with state.lock:
+        last = state.last_snapshot
+    if snapshot_text is not None:
+        payload["snapshot"] = snapshot_text
+    elif last is not None:
+        payload["snapshot"] = last
+    if message is not None:
+        payload["message"] = message
+    return payload
+
+
+def _do_snapshot(state):
+    with state.lock:
+        samples = list(state.recent)
+        w, h = state.frame_w, state.frame_h
+    if len(samples) < 5:
+        return f"not enough samples yet ({len(samples)}/5) — make sure ball is visible and steady"
+
+    xs = [p[0] for p in samples]
+    ys = [p[1] for p in samples]
+    rs = [p[2] for p in samples]
+    bx_med = int(_median(xs))
+    by_med = int(_median(ys))
+    r_med = float(_median(rs))
+    cx, cy = w // 2, h // 2
+    off_x = bx_med - cx
+    off_y = by_med - cy
+    bx_std = _pstdev(xs)
+    by_std = _pstdev(ys)
+    r_std = _pstdev(rs)
+
+    text = (
+        f"=== averaged over last {len(samples)} frames ===\n"
+        f"bx = {bx_med}  (std {bx_std:.1f})\n"
+        f"by = {by_med}  (std {by_std:.1f})\n"
+        f"r  = {r_med:.1f}  (std {r_std:.1f})\n"
+        f"image center = ({cx}, {cy})\n\n"
+        f"--- paste into modes/ball_follow.py ---\n"
+        f"CAM_GRIPPER_OFFSET_X = {off_x}\n"
+        f"CAM_GRIPPER_OFFSET_Y = {off_y}\n"
+        f"TARGET_RADIUS_PX     = {int(round(r_med))}\n"
+        f"# leave RADIUS_TOLERANCE roughly +/-{max(15, int(round(r_std * 3)))} for a safe margin\n"
+    )
+    with state.lock:
+        state.last_snapshot = text
+    print()
+    print(text)
+    return text
+
+
+def make_handler(state, arm):
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            return
+
+        def _json(self, payload, code=200):
+            body = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path in ("/", "/index.html"):
+                body = INDEX_HTML.encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if self.path == "/state":
+                self._json(_state_payload(state))
+                return
+            if self.path == "/stream":
+                self.send_response(200)
+                self.send_header("Content-Type",
+                                 "multipart/x-mixed-replace; boundary=FRAME")
+                self.send_header("Cache-Control", "no-cache, private")
+                self.send_header("Pragma", "no-cache")
+                self.end_headers()
+                last = None
+                try:
+                    while not state.quit:
+                        with state.lock:
+                            buf = state.frame_jpeg
+                        if buf and buf is not last:
+                            self.wfile.write(b"--FRAME\r\n")
+                            self.wfile.write(b"Content-Type: image/jpeg\r\n")
+                            self.wfile.write(
+                                f"Content-Length: {len(buf)}\r\n\r\n".encode())
+                            self.wfile.write(buf)
+                            self.wfile.write(b"\r\n")
+                            last = buf
+                        time.sleep(0.05)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def do_POST(self):
+            if self.path == "/snapshot":
+                text = _do_snapshot(state)
+                self._json(_state_payload(state, snapshot_text=text))
+                return
+            if self.path == "/hold":
+                if arm is None:
+                    self._json(_state_payload(state, message="--no-arm: hold ignored"))
+                    return
+                try:
+                    targets = [[sid, int(arm.getPosition(sid))] for sid in ALL_SERVO_IDS]
+                    arm.setPosition(targets, duration=1500, wait=True)
+                    msg = "torque ON at current pose"
+                except Exception as e:
+                    msg = f"hold failed: {e}"
+                print(f"[calib] {msg}")
+                self._json(_state_payload(state, message=msg))
+                return
+            if self.path == "/release":
+                if arm is None:
+                    self._json(_state_payload(state, message="--no-arm: release ignored"))
+                    return
+                try:
+                    arm.servoOff()
+                    msg = "ALL torque OFF — pose the gripper over the ball"
+                except Exception as e:
+                    msg = f"release failed: {e}"
+                print(f"[calib] {msg}")
+                self._json(_state_payload(state, message=msg))
+                return
+            if self.path == "/quit":
+                state.quit = True
+                self._json(_state_payload(state, message="exiting"))
+                return
+            self.send_response(404)
+            self.end_headers()
+
+    return Handler
+
+
+def _local_ip_hint():
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except OSError:
+        return "0.0.0.0"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Browser cam-gripper offset calibrator")
+    parser.add_argument("--camera", type=int, default=0,
+                        help="OpenCV camera index (default 0 — RZ/G3E /dev/video0)")
+    parser.add_argument("--width", type=int, default=640)
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--port", type=int, default=8000, help="HTTP listen port")
+    parser.add_argument("--no-arm", action="store_true",
+                        help="Skip xArm connection (camera-only test mode)")
+    args = parser.parse_args()
+
+    if not os.path.exists(HSV_PATH):
+        print(f"[calib] ERROR: {HSV_PATH} not found — run ball_calibrate.py first", file=sys.stderr)
+        return 1
+    with open(HSV_PATH) as f:
+        cfg = json.load(f)
+    lower = np.array([cfg["h_min"], cfg["s_min"], cfg["v_min"]], dtype=np.uint8)
+    upper = np.array([cfg["h_max"], cfg["s_max"], cfg["v_max"]], dtype=np.uint8)
+    print(f"[calib] HSV range: lower={lower.tolist()} upper={upper.tolist()}")
+
+    arm = None
+    if not args.no_arm:
+        print("[calib] connecting to xArm...")
+        arm = xarm.Controller("USB")
+        print("\n" + "=" * 60)
+        print(" SAFETY: ALL torque is about to drop. Support the arm with your")
+        print(" hand before pressing Enter, or it will swing under gravity.")
+        print("=" * 60)
+        input("[calib] Holding the arm? Press Enter to release torque... ")
+        try:
+            arm.servoOff()
+            print("[calib] torque OFF — pose the gripper directly over the ball.")
+        except Exception as e:
+            print(f"[calib] servoOff failed: {e}")
+    else:
+        print("[calib] --no-arm: running camera-only (no torque control)")
+
+    state = State()
+    cam_thread = threading.Thread(
+        target=camera_loop,
+        args=(state, args.camera, args.width, args.height, lower, upper),
+        daemon=True,
+    )
+    cam_thread.start()
+
+    handler = make_handler(state, arm)
+    server = ThreadingHTTPServer(("0.0.0.0", args.port), handler)
+    print(f"\n[calib] HTTP listening on http://{_local_ip_hint()}:{args.port}/  (Ctrl-C to quit)")
+
+    try:
+        while not state.quit:
+            server.handle_request()
+    except KeyboardInterrupt:
+        print("\n[calib] interrupted")
+    finally:
+        state.quit = True
+        cam_thread.join(timeout=2.0)
+        if arm is not None:
+            try:
+                targets = [[sid, int(arm.getPosition(sid))] for sid in ALL_SERVO_IDS]
+                arm.setPosition(targets, duration=1500, wait=True)
+                print("[calib] re-engaged torque at current pose on exit")
+            except Exception as e:
+                print(f"[calib] final hold failed: {e}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/renesas-rzg3e-evk/robotic-arm/calibrate.sh
+++ b/renesas-rzg3e-evk/robotic-arm/calibrate.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Capture HSV thresholds for the colored ball used by the ball-follow mode.
+# Writes ball_color.json next to this script.
+#
+# Defaults to the browser-based calibrator (RZ/G3E has no display server,
+# and we install opencv-python-headless so cv2.imshow won't render). Open
+# http://<board-ip>:8000/ from any PC on the same LAN once it's running.
+# Use BROWSER=0 to fall back to the original cv2-window calibrator.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [ "${BROWSER:-1}" = "0" ]; then
+    exec python3 -u ball_calibrate.py "$@"
+else
+    exec python3 -u browser_calibrate.py "$@"
+fi

--- a/renesas-rzg3e-evk/robotic-arm/calibrate_cam_offset.py
+++ b/renesas-rzg3e-evk/robotic-arm/calibrate_cam_offset.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Calibrate the camera-to-gripper pixel offset for ball_follow.
+
+Why this exists: the wrist camera is mounted a few cm away from the gripper
+fingers, so "ball at image center" does NOT mean "gripper over ball". We need
+the pixel offset between the optical axis and the gripper tip so the controller
+can aim at that pixel instead of the geometric center.
+
+Workflow:
+  1. SUPPORT THE ARM — ALL torque is about to drop.
+  2. Press Enter to release torque on every servo so you can free-pose the arm.
+  3. Place the ball on the table, then physically pose the arm so the gripper
+     is directly above the ball at the height it would normally grab from.
+  4. The live view shows the detected ball, its (bx, by), and the dx/dy from
+     image center. Those dx/dy ARE the offset.
+  5. Hold steady, press 's' + Enter — the script averages the last ~30 frames
+     and prints the CAM_GRIPPER_OFFSET_X / CAM_GRIPPER_OFFSET_Y values to paste
+     into modes/ball_follow.py.
+  6. 'h' + Enter re-enables torque at the current pose. 'r' + Enter releases
+     torque again. 'q' + Enter quits (re-enables torque first as a safety).
+"""
+
+import argparse
+import json
+import os
+import signal
+import sys
+import threading
+import time
+from collections import deque
+
+# The stdlib `statistics` module isn't shipped on the RZ/G3E's Yocto python
+# image, so reimplement the two functions we need (median, pstdev) inline.
+class _stats:
+    @staticmethod
+    def median(values):
+        s = sorted(values)
+        n = len(s)
+        if n == 0:
+            raise ValueError("median of empty sequence")
+        mid = n // 2
+        return s[mid] if n % 2 else (s[mid - 1] + s[mid]) / 2
+
+    @staticmethod
+    def pstdev(values):
+        n = len(values)
+        if n == 0:
+            return 0.0
+        mean = sum(values) / n
+        return (sum((v - mean) ** 2 for v in values) / n) ** 0.5
+
+
+statistics = _stats
+
+import cv2
+import numpy as np
+import xarm
+from xarm import Servo
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HSV_PATH = os.path.join(HERE, "ball_color.json")
+
+# Match ball_follow.py detection params so what we measure matches what it sees.
+MIN_CONTOUR_AREA = 200
+MIN_FILL_RATIO = 0.65
+SAMPLE_WINDOW = 30  # frames averaged on snapshot
+
+SERVOS = [Servo(i) for i in range(1, 7)]
+_bus_lock = threading.Lock()
+
+arm = None
+running = True
+latest = {"bx": None, "by": None, "br": None, "frame_w": 0, "frame_h": 0}
+recent = deque(maxlen=SAMPLE_WINDOW)
+
+
+def largest_blob(mask):
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    best = None
+    best_area = 0
+    for c in contours:
+        area = cv2.contourArea(c)
+        if area < MIN_CONTOUR_AREA or area <= best_area:
+            continue
+        (x, y), r = cv2.minEnclosingCircle(c)
+        if r <= 0:
+            continue
+        if area / (np.pi * r * r) < MIN_FILL_RATIO:
+            continue
+        best = (int(x), int(y), float(r))
+        best_area = area
+    return best
+
+
+def hold_current_pose():
+    """Re-enable torque by commanding each servo to its current measured position."""
+    with _bus_lock:
+        try:
+            targets = []
+            for s in SERVOS:
+                p = int(arm.getPosition(s.servo_id))
+                targets.append([s.servo_id, p])
+        except Exception as e:
+            print(f"[calib] read failed during hold: {e}")
+            return
+        arm.setPosition(targets, duration=1500, wait=True)
+
+
+def cleanup(signum=None, frame=None):
+    global running
+    running = False
+    print("\n[calib] re-enabling torque at current pose for safety...")
+    try:
+        hold_current_pose()
+    except Exception as e:
+        print(f"[calib] hold failed: {e}")
+    sys.exit(0)
+
+
+def camera_loop(cam_index, width, height, lower, upper):
+    cap = cv2.VideoCapture(cam_index)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+    if not cap.isOpened():
+        print(f"[calib] ERROR: could not open camera {cam_index}")
+        return
+
+    win = "Camera-Gripper Offset Calibrator"
+    cv2.namedWindow(win)
+    print(f"[calib] camera open ({cam_index}, {width}x{height})")
+
+    while running:
+        ok, frame = cap.read()
+        if not ok:
+            time.sleep(0.05)
+            continue
+        h, w = frame.shape[:2]
+        latest["frame_w"], latest["frame_h"] = w, h
+
+        hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv, lower, upper)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((5, 5), np.uint8))
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((9, 9), np.uint8))
+
+        ball = largest_blob(mask)
+        # Flip for display so user sees the same orientation as ball_follow.
+        annotated = cv2.flip(frame, 1)
+        cx, cy = w // 2, h // 2
+        cv2.drawMarker(annotated, (cx, cy), (255, 255, 255),
+                       markerType=cv2.MARKER_CROSS, markerSize=20, thickness=1)
+
+        if ball is not None:
+            bx, by, br = ball
+            latest["bx"], latest["by"], latest["br"] = bx, by, br
+            recent.append((bx, by))
+            dx = bx - cx
+            dy = by - cy
+            bx_disp = w - bx
+            cv2.circle(annotated, (bx_disp, by), int(br), (0, 255, 0), 2)
+            cv2.circle(annotated, (bx_disp, by), 4, (0, 255, 0), -1)
+            cv2.putText(annotated, f"bx={bx} by={by} r={int(br)}",
+                        (10, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.55,
+                        (0, 255, 0), 2, cv2.LINE_AA)
+            cv2.putText(annotated, f"OFFSET_X={dx:+d}  OFFSET_Y={dy:+d}",
+                        (10, 50), cv2.FONT_HERSHEY_SIMPLEX, 0.6,
+                        (0, 255, 255), 2, cv2.LINE_AA)
+            cv2.putText(annotated, f"samples={len(recent)}/{SAMPLE_WINDOW}",
+                        (10, 75), cv2.FONT_HERSHEY_SIMPLEX, 0.5,
+                        (200, 200, 200), 1, cv2.LINE_AA)
+        else:
+            latest["bx"] = latest["by"] = latest["br"] = None
+            cv2.putText(annotated, "no ball detected", (10, 25),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 255), 2, cv2.LINE_AA)
+
+        cv2.imshow(win, annotated)
+        cv2.waitKey(1)
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+def snapshot():
+    if len(recent) < 5:
+        print(f"[calib] not enough samples yet ({len(recent)}/5) — make sure ball is visible and steady")
+        return
+    xs = [p[0] for p in recent]
+    ys = [p[1] for p in recent]
+    bx_med = int(statistics.median(xs))
+    by_med = int(statistics.median(ys))
+    w = latest["frame_w"]
+    h = latest["frame_h"]
+    cx = w // 2
+    cy = h // 2
+    off_x = bx_med - cx
+    off_y = by_med - cy
+    bx_std = statistics.pstdev(xs) if len(xs) > 1 else 0
+    by_std = statistics.pstdev(ys) if len(ys) > 1 else 0
+
+    print()
+    print("=" * 60)
+    print(f"[calib] median over last {len(recent)} frames:")
+    print(f"        bx = {bx_med}  (std {bx_std:.1f})")
+    print(f"        by = {by_med}  (std {by_std:.1f})")
+    print(f"        image center = ({cx}, {cy})")
+    print(f"[calib] paste into modes/ball_follow.py:")
+    print(f"        CAM_GRIPPER_OFFSET_X = {off_x}")
+    print(f"        CAM_GRIPPER_OFFSET_Y = {off_y}")
+    print("=" * 60)
+    print()
+
+
+def main():
+    global arm
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--camera", type=int, default=2)
+    parser.add_argument("--width", type=int, default=640)
+    parser.add_argument("--height", type=int, default=480)
+    args = parser.parse_args()
+
+    if not os.path.exists(HSV_PATH):
+        print(f"[calib] ERROR: {HSV_PATH} not found — run ball_calibrate.py first")
+        sys.exit(1)
+    with open(HSV_PATH) as f:
+        cfg = json.load(f)
+    lower = np.array([cfg["h_min"], cfg["s_min"], cfg["v_min"]], dtype=np.uint8)
+    upper = np.array([cfg["h_max"], cfg["s_max"], cfg["v_max"]], dtype=np.uint8)
+    print(f"[calib] HSV range: lower={lower.tolist()} upper={upper.tolist()}")
+
+    print("[calib] connecting to xArm...")
+    arm = xarm.Controller('USB')
+    signal.signal(signal.SIGINT, cleanup)
+
+    print("\n" + "=" * 60)
+    print(" SAFETY: ALL torque is about to drop. Support the arm with your")
+    print(" hand before pressing Enter, or it will swing under gravity.")
+    print("=" * 60)
+    input("[calib] Holding the arm? Press Enter to release torque... ")
+
+    try:
+        arm.servoOff()
+        print("[calib] torque OFF — pose the gripper directly over the ball.")
+    except Exception as e:
+        print(f"[calib] servoOff failed: {e}")
+        sys.exit(1)
+
+    cam_thread = threading.Thread(
+        target=camera_loop,
+        args=(args.camera, args.width, args.height, lower, upper),
+        daemon=True,
+    )
+    cam_thread.start()
+
+    print("\n[calib] commands: s = snapshot   h = hold (torque on)   r = release   q = quit")
+    while True:
+        try:
+            cmd = input().strip().lower()
+        except EOFError:
+            cleanup()
+        if cmd == "s":
+            snapshot()
+        elif cmd == "h":
+            print("[calib] re-enabling torque at current pose...")
+            hold_current_pose()
+        elif cmd == "r":
+            try:
+                arm.servoOff()
+                print("[calib] torque OFF.")
+            except Exception as e:
+                print(f"[calib] servoOff failed: {e}")
+        elif cmd in ("q", "quit", "exit"):
+            cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/renesas-rzg3e-evk/robotic-arm/calibrate_offset.sh
+++ b/renesas-rzg3e-evk/robotic-arm/calibrate_offset.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Measure the camera-to-gripper pixel offset AND the ball's apparent radius
+# at grab distance. Prints constants to paste into modes/ball_follow.py.
+#
+# Defaults to the browser-based calibrator (RZ/G3E has no display server,
+# and we install opencv-python-headless so cv2.imshow won't render). Open
+# http://<board-ip>:8000/ from any PC on the same LAN once it's running.
+# Use BROWSER=0 to fall back to the original cv2-window calibrator.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [ "${BROWSER:-1}" = "0" ]; then
+    exec python3 -u calibrate_cam_offset.py "$@"
+else
+    exec python3 -u browser_calibrate_offset.py "$@"
+fi

--- a/renesas-rzg3e-evk/robotic-arm/list_usb.py
+++ b/renesas-rzg3e-evk/robotic-arm/list_usb.py
@@ -1,0 +1,23 @@
+"""List all USB devices to find XArm VID/PID."""
+import usb.core
+import usb.util
+
+
+def main():
+    print("USB Devices:")
+    devices = usb.core.find(find_all=True)
+    for device in devices:
+        try:
+            print(f"VID: 0x{device.idVendor:04x}, PID: 0x{device.idProduct:04x}")
+            print(f"  Manufacturer: {usb.util.get_string(device, device.iManufacturer)}")
+            print(f"  Product: {usb.util.get_string(device, device.iProduct)}")
+            print(f"  Serial: {usb.util.get_string(device, device.iSerialNumber)}")
+            print()
+        except:
+            print(f"VID: 0x{device.idVendor:04x}, PID: 0x{device.idProduct:04x}")
+            print("  (Could not read strings)")
+            print()
+
+
+if __name__ == "__main__":
+    main()

--- a/renesas-rzg3e-evk/robotic-arm/main.py
+++ b/renesas-rzg3e-evk/robotic-arm/main.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""
+IOTCONNECT XArm Vision Control
+
+Outer loop owns: camera, display window, IoTConnect command pump, arm bring-up.
+Per-frame inference + arm decisions live in modes/<name>.py and are selected
+with --mode. Default mode is 'asl' (the original gesture-controlled demo).
+"""
+
+import argparse
+import json
+import os
+import queue
+import threading
+import time
+from collections import deque
+from dataclasses import asdict
+from datetime import datetime
+
+import cv2
+
+import systemdata
+import xarm
+
+from modes import make_mode
+
+try:
+    from avnet.iotconnect.sdk.lite import Client, DeviceConfig, Callbacks, DeviceConfigError
+    from avnet.iotconnect.sdk.sdklib.mqtt import C2dCommand, C2dAck
+    IOTC_AVAILABLE = True
+except ImportError:
+    IOTC_AVAILABLE = False
+    Client = None
+    DeviceConfig = None
+    Callbacks = None
+    DeviceConfigError = None
+    C2dCommand = None
+    C2dAck = None
+
+
+ACTION_LABELS = {
+    'advance': "A : Advance",
+    'backup': "B : Back-Up",
+    'left': "L : Left",
+    'right': "R : Right",
+    'up': "U : Up",
+    'down': "Y : Down",
+    'home': "H : Home",
+    'move_to': "Move To Position",
+    'close_gripper': "A : Close Gripper",
+    'open_gripper': "B : Open Gripper",
+    'wrist_roll_cw': "Wrist Roll CW",
+    'wrist_roll_ccw': "Wrist Roll CCW",
+    'wrist_flex_up': "Wrist Flex Up",
+    'wrist_flex_down': "Wrist Flex Down",
+    'demo_wave': "Demo: Wave Hello",
+    'demo_bow': "Demo: Bow",
+    'demo_stretch': "Demo: Stretch Up",
+    'demo_scan': "Demo: Scan Sweep",
+    'demo_shake_no': "Demo: Shake No",
+    'demo_pickup': "Demo: Pick & Place",
+}
+
+HOME_POSITIONS = [[1, 500], [2, 500], [3, 500], [4, 500], [5, 500], [6, 500]]
+
+# Scripted demo sequences. Each item is (positions, duration_ms).
+# Every sequence must end at HOME_POSITIONS so the next action starts from a known pose.
+DEMO_SEQUENCES = {
+    'demo_wave': [
+        ([[5, 250], [4, 250], [3, 500], [2, 500]], 1500),
+        ([[2, 300]], 350),
+        ([[2, 700]], 350),
+        ([[2, 300]], 350),
+        ([[2, 700]], 350),
+        ([[2, 500]], 350),
+        (HOME_POSITIONS, 1500),
+    ],
+    'demo_bow': [
+        ([[5, 700], [4, 600], [3, 600]], 1500),
+        ([[5, 700]], 800),
+        (HOME_POSITIONS, 1500),
+    ],
+    'demo_stretch': [
+        ([[5, 150], [4, 500], [3, 500], [2, 500]], 1800),
+        ([[3, 350]], 800),
+        ([[3, 650]], 800),
+        ([[3, 500]], 400),
+        (HOME_POSITIONS, 1800),
+    ],
+    'demo_scan': [
+        ([[5, 350], [4, 400], [3, 500]], 1200),
+        ([[6, 100]], 1500),
+        ([[6, 900]], 2500),
+        ([[6, 500]], 1200),
+        (HOME_POSITIONS, 1200),
+    ],
+    'demo_shake_no': [
+        ([[5, 300], [4, 350]], 1200),
+        ([[6, 400]], 250),
+        ([[6, 600]], 250),
+        ([[6, 400]], 250),
+        ([[6, 600]], 250),
+        ([[6, 400]], 250),
+        ([[6, 500]], 250),
+        (HOME_POSITIONS, 1200),
+    ],
+    'demo_pickup': [
+        ([[1, 100]], 600),
+        ([[5, 750], [4, 650], [3, 550], [6, 500]], 1800),
+        ([[1, 650]], 700),
+        ([[5, 300], [4, 400]], 1500),
+        ([[6, 200]], 1500),
+        ([[5, 750], [4, 650]], 1500),
+        ([[1, 100]], 600),
+        ([[5, 300], [4, 400]], 1200),
+        (HOME_POSITIONS, 1500),
+    ],
+}
+
+IOTC_COMMAND_TO_ACTION = {
+    'move_to': 'move_to',
+    'move_to_home': 'home',
+    'open_gripper': 'open_gripper',
+    'close_gripper': 'close_gripper',
+    'move_forward': 'advance',
+    'move_backward': 'backup',
+    'move_left': 'left',
+    'move_right': 'right',
+    'move_up': 'up',
+    'move_down': 'down',
+    'wrist_roll_cw': 'wrist_roll_cw',
+    'wrist_roll_ccw': 'wrist_roll_ccw',
+    'wrist_flex_up': 'wrist_flex_up',
+    'wrist_flex_down': 'wrist_flex_down',
+    'demo_wave': 'demo_wave',
+    'demo_bow': 'demo_bow',
+    'demo_stretch': 'demo_stretch',
+    'demo_scan': 'demo_scan',
+    'demo_shake_no': 'demo_shake_no',
+    'demo_pickup': 'demo_pickup',
+}
+
+
+iotc_command_queue = deque()
+command_queue_lock = threading.Lock()
+iotc_publisher = None
+iotc_warning_flags = {
+    'sdk_missing': False,
+    'not_connected': False,
+}
+
+
+def iotc_on_command(msg):
+    print(f"Received IoTConnect command: {msg.command_name} args={msg.command_args} ack_id={msg.ack_id}")
+    with command_queue_lock:
+        iotc_command_queue.append(msg)
+
+
+def iotc_on_disconnect(reason: str, disconnected_from_server: bool):
+    print(f"IoTConnect disconnected ({'server' if disconnected_from_server else 'client'}): {reason}")
+
+
+def _init_iotconnect_client():
+    global iotc_publisher
+    iotc_publisher = None
+    if not IOTC_AVAILABLE:
+        if not iotc_warning_flags['sdk_missing']:
+            print('Warning: IoTConnect SDK not installed.')
+            iotc_warning_flags['sdk_missing'] = True
+        return
+
+    try:
+        device_config_path = 'iotcDeviceConfig.json'
+        if not os.path.exists(device_config_path):
+            print(f"Warning: IoTConnect device config file not found: {device_config_path}")
+            return
+
+        device_cert_path = 'device-cert.pem'
+        device_pkey_path = 'device-pkey.pem'
+        config = DeviceConfig.from_iotc_device_config_json_file(
+            device_config_json_path=device_config_path,
+            device_cert_path=device_cert_path,
+            device_pkey_path=device_pkey_path
+        )
+
+        print('Device Config', config)
+        callbacks = Callbacks(command_cb=iotc_on_command, disconnected_cb=iotc_on_disconnect)
+        iotc_publisher = Client(config=config, callbacks=callbacks)
+        iotc_publisher.connect()
+        iotc_warning_flags['not_connected'] = False
+        print('IOTCONNECT client connected')
+    except Exception as e:
+        iotc_warning_flags['not_connected'] = True
+        print(f'Warning: Failed to initialize IoTConnect client: {e}.')
+        iotc_publisher = None
+
+
+def _parse_move_to_positions(command_args):
+    if isinstance(command_args, dict):
+        if 'positions' in command_args:
+            raw_positions = command_args['positions']
+        elif 'position' in command_args:
+            raw_positions = command_args['position']
+        else:
+            raw_positions = ','.join(str(value) for value in command_args.values())
+    else:
+        raw_positions = command_args
+
+    if isinstance(raw_positions, str):
+        tokens = [token.strip() for token in raw_positions.split(',') if token.strip()]
+    elif isinstance(raw_positions, (list, tuple)):
+        tokens = [str(token).strip() for token in raw_positions if str(token).strip()]
+    else:
+        raise ValueError('move_to command_args must be a comma-separated string or list of positions')
+
+    if len(tokens) != 6:
+        raise ValueError(f'move_to requires 6 servo positions, received {len(tokens)}')
+
+    positions = []
+    for servo_id, token in enumerate(tokens, start=1):
+        positions.append([servo_id, clamp_position(int(token))])
+
+    return positions
+
+
+def process_iotconnect_commands(arm):
+    if not IOTC_AVAILABLE or iotc_publisher is None or not iotc_publisher.is_connected():
+        return
+
+    with command_queue_lock:
+        queued_commands = list(iotc_command_queue)
+        iotc_command_queue.clear()
+
+    for msg in queued_commands:
+        command_name = getattr(msg, 'command_name', '').lower()
+        command_args = getattr(msg, 'command_args', {}) or {}
+        print(f"Processing IoTConnect command '{command_name}' with args={command_args}")
+        ack_status = C2dAck.CMD_SUCCESS_WITH_ACK
+        ack_message = 'Executed command'
+        try:
+            action_name = IOTC_COMMAND_TO_ACTION.get(command_name)
+            if action_name is None:
+                ack_status = C2dAck.CMD_FAILED
+                ack_message = f"Unknown command '{command_name}'"
+                print(ack_message)
+            else:
+                action_detected = execute_arm_action(arm, action_name, command_args)
+                print(f"Action: {action_detected}")
+                send_telemetry(arm)
+        except Exception as e:
+            ack_status = C2dAck.CMD_FAILED
+            ack_message = f"Command failed: {e}"
+            print(ack_message)
+        try:
+            iotc_publisher.send_command_ack(msg, ack_status, ack_message)
+        except Exception as e:
+            print(f"Warning: Failed to send IoTConnect command ack: {e}")
+
+
+def _send_iotconnect_telemetry(payload: dict):
+    if not IOTC_AVAILABLE:
+        if not iotc_warning_flags['sdk_missing']:
+            print('Warning: IoTConnect SDK not installed.')
+            iotc_warning_flags['sdk_missing'] = True
+        return
+
+    if iotc_publisher is None or not iotc_publisher.is_connected():
+        if not iotc_warning_flags['not_connected']:
+            print('Warning: IoTConnect client not connected.')
+            iotc_warning_flags['not_connected'] = True
+        return
+
+    try:
+        iotc_publisher.send_telemetry(payload)
+    except Exception as e:
+        print(f'IoTConnect telemetry publish error: {e}')
+
+
+# Background telemetry — systemdata.collect_data() blocks ~600ms (psutil cpu_percent
+# with 0.5s interval + process iteration sleeps) and IoTConnect MQTT publish adds
+# more. Doing that synchronously from a per-frame perception loop destroys fps, so
+# we snapshot the arm positions on the caller's thread (USB HID is not multi-thread
+# safe) and hand the rest off to a worker thread.
+_telemetry_queue = queue.Queue(maxsize=1)
+_telemetry_worker_started = False
+# Tracks the currently running mode so send_telemetry can stamp every
+# payload with a top-level `state` (e.g. SCANNING/TRACKING/GRABBING/HOLDING
+# for ball mode, "ASL-Gesture" for ASL). Set by run_mode.
+_current_mode = None
+
+
+def _telemetry_worker_loop():
+    while True:
+        arm_positions, extras = _telemetry_queue.get()
+        try:
+            sysdata = systemdata.collect_data()
+            sys_obj = {'hostname': sysdata.hostname, 'uptime': sysdata.uptime, **asdict(sysdata.system_info)}
+            cpu_obj = {**asdict(sysdata.cpu), 'temp': sysdata.cpu_temp}
+            mem_obj = {**asdict(sysdata.memory), 'temp': sysdata.memory_temp}
+            telemetry = {
+                **arm_positions,
+                'sysInfo_system': sys_obj,
+                'sysInfo_cpu': cpu_obj,
+                'sysInfo_memory': mem_obj,
+                'sysInfo_storage': asdict(sysdata.storage),
+                'sysInfo_gpu': {'usage_percent': sysdata.gpu_usage, 'temp': sysdata.gpu_temp},
+            }
+            if extras:
+                telemetry.update(extras)
+            print(f"IoTConnect Telemetry: {json.dumps(telemetry)}")
+            _send_iotconnect_telemetry(telemetry)
+        except Exception as e:
+            print(f"[telemetry] worker error: {e}")
+
+
+def _ensure_telemetry_worker():
+    global _telemetry_worker_started
+    if _telemetry_worker_started:
+        return
+    _telemetry_worker_started = True
+    threading.Thread(target=_telemetry_worker_loop, daemon=True).start()
+
+
+def send_telemetry(arm, extras=None, positions=None):
+    """Publish telemetry. Pass `positions={id: pos}` to skip re-reading servos
+    (caller already did a batched read)."""
+    _ensure_telemetry_worker()
+    if positions is not None:
+        arm_positions = {
+            'gripper': positions.get(1, 0),
+            'wrist_roll': positions.get(2, 0),
+            'wrist_flex': positions.get(3, 0),
+            'elbow_flex': positions.get(4, 0),
+            'shoulder_lift': positions.get(5, 0),
+            'shoulder_pan': positions.get(6, 0),
+        }
+    else:
+        # USB HID is not thread-safe — read on caller's thread.
+        arm_positions = {
+            'gripper': arm.getPosition(1),
+            'wrist_roll': arm.getPosition(2),
+            'wrist_flex': arm.getPosition(3),
+            'elbow_flex': arm.getPosition(4),
+            'shoulder_lift': arm.getPosition(5),
+            'shoulder_pan': arm.getPosition(6),
+        }
+    # Stamp every payload with top-level `state` from the active mode.
+    if _current_mode is not None:
+        try:
+            mode_state = _current_mode.get_state()
+        except Exception as e:
+            print(f"[telemetry] get_state failed: {e}")
+            mode_state = None
+        if mode_state is not None:
+            extras = dict(extras) if extras else {}
+            extras.setdefault("state", mode_state)
+
+    item = (arm_positions, extras)
+    try:
+        _telemetry_queue.put_nowait(item)
+    except queue.Full:
+        # Drop the stale queued sample, replace with the fresh one.
+        try:
+            _telemetry_queue.get_nowait()
+        except queue.Empty:
+            pass
+        try:
+            _telemetry_queue.put_nowait(item)
+        except queue.Full:
+            pass
+
+
+def clamp_position(value, minimum=0, maximum=1000):
+    return max(minimum, min(maximum, int(value)))
+
+
+def execute_arm_action(arm, action_name, command_args=None):
+    if action_name == 'home':
+        arm.setPosition(HOME_POSITIONS, duration=1500, wait=True)
+    elif action_name == 'move_to':
+        positions = _parse_move_to_positions(command_args)
+        arm.setPosition(positions, duration=1500, wait=True)
+    elif action_name == 'open_gripper':
+        arm.setPosition(1, clamp_position(arm.getPosition(1) - 100), duration=1000, wait=True)
+    elif action_name == 'close_gripper':
+        arm.setPosition(1, clamp_position(arm.getPosition(1) + 100), duration=1000, wait=True)
+    elif action_name == 'advance':
+        arm.setPosition(5, clamp_position(arm.getPosition(5) + 100), duration=1500, wait=True)
+    elif action_name == 'backup':
+        arm.setPosition(5, clamp_position(arm.getPosition(5) - 100), duration=1500, wait=True)
+    elif action_name == 'left':
+        arm.setPosition(6, clamp_position(arm.getPosition(6) - 100), duration=1500, wait=True)
+    elif action_name == 'right':
+        arm.setPosition(6, clamp_position(arm.getPosition(6) + 100), duration=1500, wait=True)
+    elif action_name == 'up':
+        arm.setPosition(4, clamp_position(arm.getPosition(4) - 100), duration=1500, wait=True)
+    elif action_name == 'down':
+        arm.setPosition(4, clamp_position(arm.getPosition(4) + 100), duration=1500, wait=True)
+    elif action_name == 'wrist_roll_cw':
+        arm.setPosition(2, clamp_position(arm.getPosition(2) + 100), duration=1000, wait=True)
+    elif action_name == 'wrist_roll_ccw':
+        arm.setPosition(2, clamp_position(arm.getPosition(2) - 100), duration=1000, wait=True)
+    elif action_name == 'wrist_flex_up':
+        arm.setPosition(3, clamp_position(arm.getPosition(3) - 100), duration=1000, wait=True)
+    elif action_name == 'wrist_flex_down':
+        arm.setPosition(3, clamp_position(arm.getPosition(3) + 100), duration=1000, wait=True)
+    elif action_name in DEMO_SEQUENCES:
+        for positions, duration_ms in DEMO_SEQUENCES[action_name]:
+            arm.setPosition(positions, duration=duration_ms, wait=True)
+    else:
+        raise ValueError(f"Unknown action '{action_name}'")
+
+    return ACTION_LABELS[action_name]
+
+
+class _FreshCamera:
+    """Background-threaded camera reader.
+
+    The driver buffers frames internally while the main thread is blocked on
+    arm moves (wait=True). CAP_PROP_BUFFERSIZE=1 is advisory and not honored
+    by all V4L2 devices, so we run a worker that continuously grabs frames
+    and keeps only the latest. The main loop always sees a fresh frame.
+    """
+
+    def __init__(self, index, frame_w, frame_h):
+        self.cap = cv2.VideoCapture(index)
+        self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, frame_w)
+        self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, frame_h)
+        self.cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)
+        self._latest = None
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+
+    def start(self):
+        if not self.cap.isOpened():
+            return False
+        self._thread.start()
+        return True
+
+    def _loop(self):
+        while not self._stop.is_set():
+            ok, frame = self.cap.read()
+            if not ok:
+                time.sleep(0.005)
+                continue
+            with self._lock:
+                self._latest = frame
+
+    def read(self):
+        with self._lock:
+            return self._latest
+
+    def release(self):
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+        self.cap.release()
+
+
+def run_mode(arm, mode, camera_index=2, frame_w=640, frame_h=480,
+             window_title="IOTCONNECT XArm Control", headless=False, perf_every=30,
+             web_port=None):
+    """Generic camera loop. Each frame: capture -> mode.process_frame -> display -> IoTConnect cmd pump.
+    Exits on ESC or 'q' (or Ctrl-C in headless).
+
+    If ``web_port`` is set, every annotated frame is also published as
+    MJPEG on that port — point a browser at http://<board-ip>:<web_port>/
+    to watch the live demo from anywhere on the LAN. Useful on boards
+    without a local display."""
+    global _current_mode
+    cam = _FreshCamera(camera_index, frame_w, frame_h)
+    if not cam.start():
+        print("[ERROR] Camera failed to open!")
+        return
+    print(f"[INFO] Camera input: {camera_index} ({frame_w}, {frame_h}) — mode={mode.name} headless={headless}")
+
+    web = None
+    if web_port:
+        try:
+            from web_view import WebView
+            web = WebView(port=web_port)
+            print(f"[INFO] Live web view: {web.url_hint()}")
+        except Exception as e:
+            print(f"[WARN] web view failed to start on port {web_port}: {e}")
+
+    _current_mode = mode
+    mode.setup(arm)
+
+    # rolling perf counters
+    n = 0
+    t_cap_sum = 0.0
+    t_proc_sum = 0.0
+    t_total_sum = 0.0
+    t_window_start = time.time()
+
+    try:
+        # wait briefly for first frame
+        t0 = time.time()
+        while cam.read() is None and time.time() - t0 < 2.0:
+            time.sleep(0.02)
+
+        while True:
+            frame_t0 = time.perf_counter()
+            t_a = time.perf_counter()
+            frame = cam.read()
+            if frame is None:
+                time.sleep(0.01)
+                continue
+            t_cap = time.perf_counter() - t_a
+
+            t_b = time.perf_counter()
+            display = mode.process_frame(frame, arm)
+            t_proc = time.perf_counter() - t_b
+            if display is None:
+                display = frame
+
+            if not headless:
+                cv2.imshow(window_title, display)
+                key = cv2.waitKey(1)
+                if key == 27 or key == 113:
+                    break
+
+            if web is not None:
+                try:
+                    web.publish(display, state=mode.get_state(), mode=mode.name)
+                except Exception as e:
+                    print(f"[web] publish failed: {e}")
+
+            if arm is not None:
+                process_iotconnect_commands(arm)
+
+            t_total = time.perf_counter() - frame_t0
+            n += 1
+            t_cap_sum += t_cap
+            t_proc_sum += t_proc
+            t_total_sum += t_total
+            if n >= perf_every:
+                elapsed = time.time() - t_window_start
+                fps = n / elapsed if elapsed > 0 else 0.0
+                print(f"[perf] n={n} fps={fps:.1f}  cap={t_cap_sum/n*1000:.1f}ms  "
+                      f"proc={t_proc_sum/n*1000:.1f}ms  total={t_total_sum/n*1000:.1f}ms")
+                if web is not None:
+                    web.publish(display, fps_hint=fps)
+                n = 0
+                t_cap_sum = t_proc_sum = t_total_sum = 0.0
+                t_window_start = time.time()
+    finally:
+        mode.teardown(arm)
+        cam.release()
+        if not headless:
+            cv2.destroyAllWindows()
+        if web is not None:
+            web.stop()
+        _current_mode = None
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="IOTCONNECT XArm vision demo")
+    parser.add_argument('--mode', default='ball',
+                        help="Vision mode (default: ball — the supported mode on RZ/G3E. "
+                             "Use 'asl' only if torch + mediapipe are installed)")
+    parser.add_argument('--camera', type=int, default=0,
+                        help="OpenCV camera index (default: 0 — RZ/G3E exposes the USB UVC camera as /dev/video0)")
+    parser.add_argument('--headless', action='store_true', help="Disable preview window (for SSH/perf testing)")
+    parser.add_argument('--perf-every', type=int, default=30, help="Print perf stats every N frames")
+    parser.add_argument('--web-port', type=int, default=None,
+                        help="Serve live MJPEG view of the annotated frames on this port "
+                             "(e.g. 8000). Open http://<board-ip>:<port>/ in a browser.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    arm = None
+    try:
+        print("Connecting to XArm 1S...")
+        arm = xarm.Controller('USB')
+        print("Connected to XArm 1S successfully!")
+
+        print("Connecting to IoTConnect...")
+        _init_iotconnect_client()
+        if iotc_publisher is not None and iotc_publisher.is_connected():
+            print("Connected to IoTConnect successfully!")
+        else:
+            print("IoTConnect is unavailable; running without cloud connectivity.")
+
+        print("Initializing to home position...")
+        arm.setPosition(HOME_POSITIONS, duration=2000, wait=True)
+        print("Home position reached!")
+
+        mode = make_mode(args.mode)
+        print(f"Starting vision mode: {mode.name}")
+        run_mode(arm, mode, camera_index=args.camera,
+                 headless=args.headless, perf_every=args.perf_every,
+                 web_port=args.web_port)
+
+    except Exception as e:
+        print(f"Error: {e}")
+        print("Make sure XArm 1S is connected via USB and powered on.")
+        print("Also ensure camera is available and any required model files exist.")
+
+    finally:
+        try:
+            print("Turning off servos...")
+            if arm is not None:
+                arm.servoOff()
+        except Exception:
+            pass
+        if iotc_publisher is not None:
+            try:
+                iotc_publisher.disconnect()
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/renesas-rzg3e-evk/robotic-arm/model/get_model.sh
+++ b/renesas-rzg3e-evk/robotic-arm/model/get_model.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Get models from github.com/AlbertaBeef/asl_mediapipe_pointnet
+#wget https://github.com/AlbertaBeef/asl_mediapipe_pointnet/releases/download/pointnet_hands_version_1/point_net_1.pth
+wget https://github.com/AlbertaBeef/asl_mediapipe_pointnet/releases/download/pointnet_hands_version_2/point_net_1.pth

--- a/renesas-rzg3e-evk/robotic-arm/modes/__init__.py
+++ b/renesas-rzg3e-evk/robotic-arm/modes/__init__.py
@@ -1,0 +1,13 @@
+from .base import Mode
+
+__all__ = ["Mode", "make_mode"]
+
+
+def make_mode(name: str) -> Mode:
+    if name == "asl":
+        from .asl import ASLMode
+        return ASLMode()
+    if name == "ball":
+        from .ball_follow import BallFollowMode
+        return BallFollowMode()
+    raise ValueError(f"Unknown mode: {name}")

--- a/renesas-rzg3e-evk/robotic-arm/modes/asl.py
+++ b/renesas-rzg3e-evk/robotic-arm/modes/asl.py
@@ -1,0 +1,173 @@
+"""ASL gesture-recognition mode.
+
+Wraps the original MediaPipe + PointNet pipeline. Per-frame: detect hands,
+classify the sign with PointNet, and dispatch a mapped arm action. Only one
+action fires per distinct gesture (cooldown until the recognized sign changes).
+"""
+
+import os
+import time
+
+import cv2
+import mediapipe as mp
+import numpy as np
+import torch
+
+from .base import Mode
+
+TELEMETRY_INTERVAL_S = 2.0
+
+try:
+    from point_net import PointNet
+except ImportError:
+    print("Warning: point_net module not found. Please ensure model/point_net.py exists and that the project root is on PYTHONPATH.")
+    PointNet = None
+
+
+CHAR2INT = {
+    "A": 0, "B": 1, "C": 2, "D": 3, "E": 4, "F": 5, "G": 6, "H": 7, "I": 8, "K": 9, "L": 10,
+    "M": 11, "N": 12, "O": 13, "P": 14, "Q": 15, "R": 16, "S": 17, "T": 18, "U": 19,
+    "V": 20, "W": 21, "X": 22, "Y": 23,
+}
+INT2CHAR = {v: k for k, v in CHAR2INT.items()}
+
+LEFT_GESTURE_TO_ACTION = {
+    'A': 'advance', 'B': 'backup', 'L': 'left', 'R': 'right',
+    'U': 'up', 'Y': 'down', 'H': 'home',
+}
+RIGHT_GESTURE_TO_ACTION = {
+    'A': 'close_gripper', 'B': 'open_gripper',
+}
+
+TEXT_FONT = cv2.FONT_HERSHEY_SIMPLEX
+TEXT_SIZE = 0.75
+TEXT_LINE = 2
+
+
+class ASLMode(Mode):
+    name = "asl"
+
+    def __init__(self, model_dir="./model", model_name="point_net_1.pth"):
+        self.model_dir = model_dir
+        self.model_name = model_name
+        self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        self.model = None
+        self.hands = None
+        self.last_gesture = None
+        self.gesture_cooldown = 0
+        self.last_telemetry_at = 0.0
+
+    def get_state(self):
+        return "ASL-Gesture"
+
+    def setup(self, arm):
+        if PointNet is None:
+            raise RuntimeError("PointNet module not available; cannot run ASL mode.")
+        path = os.path.join(self.model_dir, self.model_name)
+        self.model = torch.load(path, weights_only=False, map_location=self.device)
+        print(f"PointNet model loaded from {path}")
+        mp_hands = mp.solutions.hands
+        self.hands = mp_hands.Hands(min_detection_confidence=0.5, min_tracking_confidence=0.5)
+        self._mp_hands = mp_hands
+
+    def teardown(self, arm):
+        if self.hands is not None:
+            self.hands.close()
+            self.hands = None
+
+    def process_frame(self, frame, arm):
+        # Inject lazily to avoid a circular import at module load time.
+        from main import execute_arm_action, send_telemetry, ACTION_LABELS
+
+        cv2_image = cv2.flip(frame.copy(), 1)
+        results = self.hands.process(cv2_image)
+        h, w, _ = cv2_image.shape
+        annotated = cv2_image.copy()
+        current_gesture = None
+
+        if results.multi_hand_landmarks:
+            for hand_id, hand_landmarks in enumerate(results.multi_hand_landmarks):
+                handedness = results.multi_handedness[hand_id].classification[0].label
+
+                if handedness == "Left":
+                    hand_x, hand_y, hand_color, hand_msg = 10, 30, (0, 255, 0), 'LEFT='
+                else:
+                    hand_x, hand_y, hand_color, hand_msg = w - 128, 30, (0, 0, 255), 'RIGHT='
+
+                points_raw = np.array([[lm.x, lm.y, lm.z] for lm in hand_landmarks.landmark])
+                points_norm = points_raw.copy()
+                min_x, max_x = points_raw[:, 0].min(), points_raw[:, 0].max()
+                min_y, max_y = points_raw[:, 1].min(), points_raw[:, 1].max()
+                if max_x > min_x:
+                    points_norm[:, 0] = (points_norm[:, 0] - min_x) / (max_x - min_x)
+                if max_y > min_y:
+                    points_norm[:, 1] = (points_norm[:, 1] - min_y) / (max_y - min_y)
+                if handedness == "Right":
+                    points_norm[:, 0] = 1.0 - points_norm[:, 0]
+
+                for hc in self._mp_hands.HAND_CONNECTIONS:
+                    cv2.line(
+                        annotated,
+                        (int(points_raw[hc[0]][0] * w), int(points_raw[hc[0]][1] * h)),
+                        (int(points_raw[hc[1]][0] * w), int(points_raw[hc[1]][1] * h)),
+                        hand_color, 2,
+                    )
+
+                try:
+                    pointst = torch.tensor([points_norm]).float().to(self.device)
+                    label = self.model(pointst).detach().cpu().numpy()
+                    asl_id = int(np.argmax(label))
+                    asl_sign = INT2CHAR[asl_id]
+                    confidence = float(label[0][asl_id])
+
+                    cv2.putText(annotated, hand_msg + asl_sign, (hand_x, hand_y),
+                                TEXT_FONT, TEXT_SIZE, hand_color, TEXT_LINE, cv2.LINE_AA)
+
+                    action_name = (LEFT_GESTURE_TO_ACTION if handedness == "Left"
+                                   else RIGHT_GESTURE_TO_ACTION).get(asl_sign)
+                    if action_name:
+                        cv2.putText(annotated, '[' + ACTION_LABELS[action_name] + ']',
+                                    (hand_x, hand_y * 2),
+                                    TEXT_FONT, TEXT_SIZE, hand_color, TEXT_LINE, cv2.LINE_AA)
+
+                    current_gesture = (handedness, asl_sign, confidence)
+                except Exception as e:
+                    print(f"[ERROR] ASL classification: {e}")
+
+        if self.gesture_cooldown > 0:
+            self.gesture_cooldown -= 1
+        elif current_gesture is not None:
+            sig = current_gesture[:2]
+            if sig != self.last_gesture:
+                self.last_gesture = sig
+                self.gesture_cooldown = 1
+                self._dispatch(arm, current_gesture[0], current_gesture[1],
+                               execute_arm_action, send_telemetry, ACTION_LABELS)
+
+        now = time.time()
+        if now - self.last_telemetry_at >= TELEMETRY_INTERVAL_S:
+            self.last_telemetry_at = now
+            try:
+                send_telemetry(arm)
+            except Exception as e:
+                print(f"[asl] telemetry failed: {e}")
+
+        return annotated
+
+    @staticmethod
+    def _dispatch(arm, handedness, sign, execute_arm_action, send_telemetry, action_labels):
+        if handedness == 'Left':
+            action_name = LEFT_GESTURE_TO_ACTION.get(sign)
+        elif handedness == 'Right':
+            action_name = RIGHT_GESTURE_TO_ACTION.get(sign)
+        else:
+            print(f"Unknown handedness '{handedness}' for gesture '{sign}'")
+            return
+        if not action_name:
+            return
+        try:
+            execute_arm_action(arm, action_name)
+            print(f"Action: {action_labels[action_name]}")
+            send_telemetry(arm)
+        except Exception as e:
+            print(f"Error controlling arm: {e}")

--- a/renesas-rzg3e-evk/robotic-arm/modes/ball_follow.py
+++ b/renesas-rzg3e-evk/robotic-arm/modes/ball_follow.py
@@ -1,0 +1,573 @@
+"""Ball-follow mode (eye-in-hand visual servoing).
+
+Reads HSV thresholds from ball_color.json, segments the ball each frame, and
+runs a small proportional controller to:
+  1) center the ball in the wrist-camera frame (shoulder_pan + wrist_flex)
+  2) advance until the ball's apparent radius hits a target (shoulder_lift)
+  3) close the gripper, lift, return to home
+
+State machine: IDLE -> TRACKING -> GRABBING -> AFTER_GRAB -> IDLE.
+"""
+
+import json
+import os
+import time
+from collections import deque
+
+import cv2
+import numpy as np
+from xarm import Servo
+
+from .base import Mode
+
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "ball_color.json")
+
+# --- tuning knobs ---
+UPDATE_EVERY = 1           # one command per frame; each blocks until done so further throttling pointless
+PAN_GAIN = 0.04            # servo units per pixel of horizontal error
+TILT_GAIN = 0.10           # servo units per pixel of vertical error — higher than PAN because wrist_flex is fighting gravity at extended poses; raw step grows fast with error so MAX_STEP gets reached and motion is visible
+# Sign of correction. +1 if "servo value goes up" corresponds to "camera view
+# moves in the +x/+y direction of the pixel frame". Flip either to -1 if the
+# arm moves AWAY from the ball. Determined by live test, not theory.
+PAN_DIR = 1               # MUST stay -1 for current wall mount; verified by user repeatedly. Do NOT flip without explicit instruction.
+TILT_DIR = -1              # was 1; flipped 2026-04-18 — logs showed wrist_flex driving UP when ball was already in top of frame (tilt_err got worse over time)
+APPROACH_STEP = 15         # shoulder_lift step toward the ball when too far. Raised from 6 on 2026-04-19 — at extended poses (shoulder_lift>600) a 6-unit command silently fails to break shoulder_lift's static friction, same friction-floor failure mode as MIN_TRIM_STEP_PAN. Lift sat at 630 for many seconds with d_lift=6 firing every frame; ball never got closer. 15 is enough to actually move the servo. Wrist co-trim during descent absorbs the larger per-step ball-shift in the frame.
+ELBOW_REACH_RATIO = 0.6    # elbow_flex contribution per unit of shoulder_lift during approach
+TILT_ELBOW_RATIO = 0.0     # disabled 2026-04-19 — telemetry showed elbow_flex draining to floor (clamp=0) because tilt's negative contribution outweighed approach's positive one over many frames; once elbow saturates the assist is wasted anyway. Wrist alone handles tilt with the wider CENTER_DEADBAND_PX
+TILT_ELBOW_DIR = 1         # flip to -1 if elbow moves wrong way for tilt
+MAX_STEP = 25              # cap on any single-update servo delta — raised so larger errors actually translate to a visible move; the bus servo has plenty of torque headroom for 25-unit steps
+MIN_TRIM_STEP = 8          # any non-zero trim is bumped to at least this magnitude — bus servos ignore <5-unit commands (static friction), so a 3-unit "trim" is a no-op and tilt_err sits forever just outside CENTER_DEADBAND_PX without ever converging. Tuned for wrist_flex.
+MIN_TRIM_STEP_PAN = 18     # shoulder_pan carries the whole forearm + wrist + camera, so its static friction is much higher than wrist_flex — 8-unit commands stall in extended poses (shoulder_lift>600). Verified 2026-04-19 with telemetry showing pan stuck at 552-553 while controller commanded +8 every frame.
+MOVE_DURATION_MS = 220     # per-step move duration; raised so small servo commands actually move (under 150ms many bus servos ignore sub-5-unit deltas)
+CENTER_DEADBAND_PX = 60    # widened 2026-04-19 from 25 — must be >= MIN_TRIM_STEP_PAN × pixels-per-servo-unit (~7 px/unit measured), otherwise a single floored pan command (18 units = ~126 px of ball motion) flings the ball clear past the deadband and the controller oscillates +18, -18, +18 forever. Trade-off: GRAB now fires at up to 60 px off-target, but the gripper jaw is wider than that
+APPROACH_DEADBAND_PX = 60  # tightened to match CENTER_DEADBAND_PX 2026-04-19 — looser values (was 120) let lift descent re-open tilt_err every frame, racing the wrist correction so tilt_err never converged. With this value the controller serializes: center first, then descend, then re-center if descent geometry re-opens tilt
+TARGET_RADIUS_PX = 220     # ball "close enough" radius in pixels (lowered to match what we actually observe at grab distance for the current ball)
+RADIUS_TOLERANCE = 40      # +/- around TARGET_RADIUS_PX considered "at distance"
+MIN_CONTOUR_AREA = 200     # ignore tiny mask blobs (noise)
+MIN_FILL_RATIO = 0.65      # contour_area / enclosing_circle_area; ball ≈0.85+, irregular blobs typically <0.5
+# Camera-to-gripper offset in image pixels — measured 2026-04-18 with
+# calibrate_cam_offset.py: arm posed so gripper was physically over the ball,
+# then median (bx-320, by-240) over ~30 frames. The negative X means the
+# gripper sits to the LEFT of the camera optical axis in raw frame coords;
+# Y > 0 means the gripper sits BELOW the optical axis. Controller now aims
+# at this pixel so "centered" actually means "gripper over ball".
+CAM_GRIPPER_OFFSET_X = 0
+CAM_GRIPPER_OFFSET_Y = 0
+# --- search envelope ---
+PAN_MIN = 300              # shoulder_pan clamped to [PAN_MIN, PAN_MAX] during live tracking
+PAN_MAX = 800
+# Hard safety limits so an approach that never satisfies radius_ok (bad HSV, wrong-sized ball,
+# mis-set TARGET_RADIUS_PX) can't drive the gripper into the table. Tune by teach-mode probing.
+LIFT_MAX = 800             # shoulder_lift ceiling during approach (larger = reach further down)
+ELBOW_MAX = 500            # elbow_flex ceiling during approach
+SCAN_DWELL_S = 1.5         # hold each scan pose this long before advancing
+SCAN_MOVE_MS = 2500        # duration for the move between scan poses (slowed so right-pose lift=635 doesn't plunge toward table)
+NO_BALL_GRACE_FRAMES = 30  # ~5s at 6 fps — hold pose when ball briefly disappears (clipping, HSV flicker) instead of bouncing back to scan; the scan re-entry was producing the visible "shaking" between brief-track and scan-move every time detection flickered
+# --- prediction + telemetry ---
+ENABLE_PREDICTION = False        # master switch for extrapolating ball motion when it's lost
+POS_BUFFER_LEN = 5               # how many recent ball positions we keep for velocity est
+MIN_VELOCITY_PX_PER_FRAME = 2.0  # velocity below this = don't bother predicting
+MAX_PREDICT_FRAMES = 15          # cap predictions so the arm doesn't run away on a bad estimate
+TELEMETRY_INTERVAL_S = 2.0       # how often we publish ball telemetry to IoTConnect
+GRIPPER_CLOSE_TARGET = 650  # commanded close position; actual may stall below this on large objects
+GRIPPER_STALL_SLACK = 10    # if actual < target - this, assume stalled against object
+GRIPPER_RELAX_OFFSET = 5    # back off this many units from the stall point to release torque
+GRIPPER_RELEASE_DELTA = 40  # if current pos < hold_target - this, user opened the gripper
+
+# --- arm conventions (from main.execute_arm_action) ---
+SERVO_GRIPPER = 1
+SERVO_WRIST_ROLL = 2
+SERVO_WRIST_FLEX = 3       # smaller = camera tilts up; larger = camera tilts down
+SERVO_ELBOW_FLEX = 4
+SERVO_SHOULDER_LIFT = 5    # smaller = lift up; larger = reach forward/down
+SERVO_SHOULDER_PAN = 6     # smaller = pan left; larger = pan right (verify w/ live test)
+
+# Scan poses — cycled through while no ball is seen. Captured 2026-04-18 via
+# teach_pose.py for the wall/VESA-mounted arm looking down at the table.
+# wrist_roll forced to 500 (neutral) so the wrist_flex axis produces pure
+# pitch. Off-neutral roll rotates the image, which decouples pixel dx/dy
+# from the pan/flex servos and causes tracking to oscillate.
+SCAN_POSES = [
+    # center
+    [[SERVO_SHOULDER_PAN, 499], [SERVO_SHOULDER_LIFT, 242], [SERVO_ELBOW_FLEX, 277],
+     [SERVO_WRIST_FLEX, 900], [SERVO_WRIST_ROLL, 500], [SERVO_GRIPPER, 250]],
+    # left edge
+    [[SERVO_SHOULDER_PAN, 346], [SERVO_SHOULDER_LIFT, 213], [SERVO_ELBOW_FLEX, 241],
+     [SERVO_WRIST_FLEX, 876], [SERVO_WRIST_ROLL, 494], [SERVO_GRIPPER, 258]],
+    # right edge
+    [[SERVO_SHOULDER_PAN, 736], [SERVO_SHOULDER_LIFT, 214], [SERVO_ELBOW_FLEX, 240],
+     [SERVO_WRIST_FLEX, 855], [SERVO_WRIST_ROLL, 495], [SERVO_GRIPPER, 257]],
+]
+SCAN_POSE_LABELS = ["center", "left", "right"]
+
+# TODO: replace with recaptured home pose — prior snapshot had a corrupt elbow reading.
+HOME_POSE = [[s, 500] for s in range(1, 7)]
+# Same as HOME_POSE but excludes the gripper, so a held object isn't dropped.
+HOME_POSE_KEEP_GRIP = [[s, 500] for s in range(2, 7)]
+
+
+# Reusable Servo objects so batched getPosition doesn't allocate per frame.
+_ALL_SERVOS = [Servo(i) for i in range(1, 7)]
+
+
+def _read_all_positions(arm):
+    """Per-servo reads of all six positions. Returns {id: pos}.
+
+    We do NOT use the batched ``arm.getPosition([Servo...])`` call: when its
+    response parse throws IndexError it leaves leftover bytes in the HID read
+    buffer, permanently desynchronising the stream. Every subsequent read
+    then mis-parses and the process must be restarted with a USB power-cycle.
+    Per-servo reads cost ~6 USB RTTs (~40 ms) but don't poison the stream.
+    """
+    return {sid: int(arm.getPosition(sid)) for sid in range(1, 7)}
+
+
+def _clamp(v, lo=0, hi=1000):
+    return max(lo, min(hi, int(v)))
+
+
+def _step_toward(error_px, gain, max_step, min_step=MIN_TRIM_STEP):
+    """Convert a pixel error to a clamped servo delta (sign preserved).
+
+    Floors the magnitude at ``min_step`` so trims aren't silently swallowed by
+    bus-servo static friction. Caller still gates on a separate deadband check
+    before invoking this, so the floor only applies when we've already decided
+    a move is warranted.
+    """
+    raw = error_px * gain
+    if raw > max_step:
+        return max_step
+    if raw < -max_step:
+        return -max_step
+    if raw > 0 and raw < min_step:
+        return min_step
+    if raw < 0 and raw > -min_step:
+        return -min_step
+    return raw
+
+
+class BallFollowMode(Mode):
+    name = "ball"
+
+    def __init__(self):
+        self.lower = None
+        self.upper = None
+        self.frame_count = 0
+        self.state = "IDLE"
+        self.last_log = ""
+        self.hold_target = None  # gripper position we're holding at; None = not holding
+        self.no_ball_frames = 0  # consecutive frames with no ball detected
+        self.pos_buffer = deque(maxlen=POS_BUFFER_LEN)  # (frame_idx, bx, by, br)
+        self.pred_x = 0.0
+        self.pred_y = 0.0
+        self.pred_r = 0.0
+        self.pred_frames_remaining = 0
+        self.last_vel = (0.0, 0.0)
+        self.last_ball = (0, 0, 0)   # most recent (bx, by, br), real or predicted
+        self.last_errs = (0, 0, 0)   # pan_err, tilt_err, radius_err
+        self.last_deltas = (0, 0, 0, 0)  # d_pan, d_tilt, d_lift, d_elbow
+        self.last_is_prediction = False
+        self.last_telemetry_at = 0.0
+        self.scan_idx = 0
+        self.last_scan_move_at = 0.0
+        # perf instrumentation (printed from process_frame every PERF_EVERY frames)
+        self._perf_n = 0
+        self._perf_detect = 0.0
+        self._perf_arm = 0.0
+        self._perf_every = 30
+
+    def setup(self, arm):
+        if not os.path.exists(CONFIG_PATH):
+            raise RuntimeError(f"ball_color.json not found at {CONFIG_PATH}; run ball_calibrate.py first")
+        with open(CONFIG_PATH) as f:
+            cfg = json.load(f)
+        self.lower = np.array([cfg["h_min"], cfg["s_min"], cfg["v_min"]], dtype=np.uint8)
+        self.upper = np.array([cfg["h_max"], cfg["s_max"], cfg["v_max"]], dtype=np.uint8)
+        print(f"[ball] HSV range loaded: lower={self.lower.tolist()} upper={self.upper.tolist()}")
+        print(f"[ball] moving to scan pose [{SCAN_POSE_LABELS[0]}]...")
+        arm.setPosition(SCAN_POSES[0], duration=1500, wait=True)
+        self.scan_idx = 0
+        self.last_scan_move_at = time.time()
+        self.state = "IDLE"
+
+    def process_frame(self, frame, arm):
+        from main import send_telemetry  # lazy to avoid circular import
+
+        self.frame_count += 1
+        h, w = frame.shape[:2]
+        # Aim at the pixel where the ball appears when the gripper is over it,
+        # not the geometric image center. See CAM_GRIPPER_OFFSET_X/Y.
+        cx_target = w // 2 + CAM_GRIPPER_OFFSET_X
+        cy_target = h // 2 + CAM_GRIPPER_OFFSET_Y
+
+        # Single batched USB read for all 6 servos, reused below.
+        # If even the per-servo fallback inside _read_all_positions fails,
+        # skip this frame — commanding setPosition with bogus "current" values
+        # (e.g. all 500s) would make the arm jump.
+        try:
+            pos = _read_all_positions(arm)
+        except Exception as e:
+            print(f"[ball] position read failed entirely — skipping frame: {e}")
+            return cv2.flip(frame, 1)
+
+        # If we're currently holding something, skip tracking entirely.
+        # User can open the gripper (via IoTConnect) to release and resume.
+        if self.hold_target is not None:
+            gpos = pos[SERVO_GRIPPER]
+            if gpos < self.hold_target - GRIPPER_RELEASE_DELTA:
+                self._log(f"RELEASED: gripper {gpos} < hold_target {self.hold_target} - {GRIPPER_RELEASE_DELTA}")
+                self.hold_target = None
+            else:
+                annotated = cv2.flip(frame, 1)
+                cv2.putText(annotated, f"HOLDING @ {gpos} — tracking paused",
+                            (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7,
+                            (0, 255, 255), 2, cv2.LINE_AA)
+                self._log(f"HOLDING: pos={gpos} target={self.hold_target}")
+                self.state = "IDLE"
+                return annotated
+
+        t_detect_start = time.perf_counter()
+        hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv, self.lower, self.upper)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((5, 5), np.uint8))
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((9, 9), np.uint8))
+
+        real_ball = self._largest_blob(mask)
+        t_detect = time.perf_counter() - t_detect_start
+        is_prediction = False
+        ball = real_ball
+        if real_ball is None:
+            predicted = self._maybe_predict()
+            if predicted is not None:
+                ball = predicted
+                is_prediction = True
+        else:
+            # Real observation — record it and cancel any in-progress prediction.
+            self.pos_buffer.append((self.frame_count, real_ball[0], real_ball[1], real_ball[2]))
+            self.pred_frames_remaining = 0
+            # If we were scanning and just acquired the ball, halt the in-flight
+            # scan move (which has duration=SCAN_MOVE_MS — could still be panning
+            # for another 1-2s). Without this, the arm keeps sweeping past the
+            # ball before the small per-frame TRACKING commands can take hold,
+            # producing the "overshoot then chase back" pattern.
+            if self.no_ball_frames > 0:
+                try:
+                    halt_targets = [
+                        [SERVO_SHOULDER_PAN, pos[SERVO_SHOULDER_PAN]],
+                        [SERVO_WRIST_FLEX, pos[SERVO_WRIST_FLEX]],
+                        [SERVO_SHOULDER_LIFT, pos[SERVO_SHOULDER_LIFT]],
+                        [SERVO_ELBOW_FLEX, pos[SERVO_ELBOW_FLEX]],
+                    ]
+                    arm.setPosition(halt_targets, duration=80, wait=False)
+                    print(f"[ball] HALT scan: pan={pos[SERVO_SHOULDER_PAN]} "
+                          f"flex={pos[SERVO_WRIST_FLEX]} lift={pos[SERVO_SHOULDER_LIFT]} "
+                          f"elbow={pos[SERVO_ELBOW_FLEX]}")
+                except Exception as e:
+                    print(f"[ball] halt failed: {e}")
+            self.no_ball_frames = 0
+
+        # Flip first so all text we draw below reads the right way around.
+        # Ball x-coords must be mirrored too: bx_disp = w - bx.
+        annotated = cv2.flip(frame, 1)
+        # Mirror the target x for display since the frame is flipped horizontally.
+        cv2.drawMarker(annotated, (w - cx_target, cy_target), (255, 255, 255),
+                       markerType=cv2.MARKER_CROSS, markerSize=20, thickness=1)
+
+        if self.state == "GRABBING":
+            cv2.putText(annotated, "GRABBING...", (10, 30),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 255, 255), 2, cv2.LINE_AA)
+            return annotated
+
+        if ball is None:
+            # truly lost — nothing real, nothing to predict from
+            self.no_ball_frames += 1
+            label = SCAN_POSE_LABELS[self.scan_idx]
+            self._log(f"SCAN[{label}]: no ball ({self.no_ball_frames})")
+            cv2.putText(annotated, f"scan {label}  no ball ({self.no_ball_frames})", (10, 30),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 255), 2, cv2.LINE_AA)
+            self.state = "SCANNING"
+            self.last_is_prediction = False
+            # After a brief grace period, cycle scan poses to search the table.
+            # wait=False so the camera loop keeps reading frames during the move
+            # (otherwise video freezes for SCAN_MOVE_MS each transition). We pace
+            # transitions ourselves: don't advance until the prior move's expected
+            # completion time has passed plus SCAN_DWELL_S of viewing time.
+            if self.no_ball_frames >= NO_BALL_GRACE_FRAMES:
+                now = time.time()
+                next_advance_at = self.last_scan_move_at + (SCAN_MOVE_MS / 1000.0) + SCAN_DWELL_S
+                if now >= next_advance_at:
+                    self.scan_idx = (self.scan_idx + 1) % len(SCAN_POSES)
+                    next_label = SCAN_POSE_LABELS[self.scan_idx]
+                    print(f"[ball] scanning -> {next_label}")
+                    try:
+                        arm.setPosition(SCAN_POSES[self.scan_idx], duration=SCAN_MOVE_MS, wait=False)
+                    except Exception as e:
+                        print(f"[ball] scan move failed: {e}")
+                    self.last_scan_move_at = time.time()
+            self._maybe_send_telemetry(arm, send_telemetry, positions=pos)
+            return annotated
+
+        bx, by, br = ball
+        bx_disp = w - bx
+        color = (0, 165, 255) if is_prediction else (0, 255, 0)  # orange vs green
+        cv2.circle(annotated, (bx_disp, by), int(br), color, 2)
+        cv2.circle(annotated, (bx_disp, by), 4, color, -1)
+        if is_prediction:
+            cv2.putText(annotated, f"PREDICTING ({self.pred_frames_remaining} left)",
+                        (10, 80), cv2.FONT_HERSHEY_SIMPLEX, 0.55,
+                        (0, 165, 255), 2, cv2.LINE_AA)
+        pan_err = bx - cx_target
+        tilt_err = by - cy_target
+        radius_err = TARGET_RADIUS_PX - br
+        centered_ok = abs(pan_err) <= CENTER_DEADBAND_PX and abs(tilt_err) <= CENTER_DEADBAND_PX
+        # Looser gate that just requires the ball to be roughly under the gripper:
+        # used to allow descent while pan/tilt are still trimming, so we don't
+        # sit forever waiting for perfect centering before reaching for the ball.
+        approach_centered_ok = abs(pan_err) <= APPROACH_DEADBAND_PX and abs(tilt_err) <= APPROACH_DEADBAND_PX
+        radius_ok = abs(radius_err) <= RADIUS_TOLERANCE
+        cv2.putText(annotated,
+                    f"r={int(br)} dx={pan_err:+d} dy={tilt_err:+d}",
+                    (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 0), 2, cv2.LINE_AA)
+        cv2.putText(annotated,
+                    f"center={'OK' if centered_ok else 'NO'}  radius={'OK' if radius_ok else 'NO'} (target={TARGET_RADIUS_PX}+/-{RADIUS_TOLERANCE})",
+                    (10, 55), cv2.FONT_HERSHEY_SIMPLEX, 0.55,
+                    (0, 255, 0) if centered_ok and radius_ok else (0, 200, 255),
+                    2, cv2.LINE_AA)
+
+        # Are we close + centered enough to grab? Only on real observations —
+        # never close the gripper on a predicted position.
+        if not is_prediction and centered_ok and radius_ok:
+            self.state = "GRABBING"
+            self._log("GRAB: centered and at distance — closing gripper")
+            self._do_grab(arm)
+            self.state = "HOLDING"
+            try:
+                send_telemetry(arm)
+            except Exception as e:
+                print(f"[ball] telemetry after grab failed: {e}")
+            self.state = "IDLE"
+            return annotated
+
+        # Throttle servo commands so we don't spam at full frame rate.
+        if self.frame_count % UPDATE_EVERY != 0:
+            return annotated
+
+        self.state = "PREDICTING" if is_prediction else "TRACKING"
+        d_pan = 0
+        d_tilt = 0
+        d_lift = 0
+        d_elbow = 0
+
+        if abs(pan_err) > CENTER_DEADBAND_PX:
+            d_pan = int(round(_step_toward(pan_err, PAN_GAIN, MAX_STEP,
+                                            min_step=MIN_TRIM_STEP_PAN))) * PAN_DIR
+        if abs(tilt_err) > CENTER_DEADBAND_PX:
+            d_tilt = int(round(_step_toward(tilt_err, TILT_GAIN, MAX_STEP))) * TILT_DIR
+            # Elbow helps with larger tilts so wrist_flex doesn't max out alone.
+            d_elbow += int(round(d_tilt * TILT_ELBOW_RATIO)) * TILT_ELBOW_DIR
+        # Allow descent as soon as the ball is roughly under the gripper
+        # (looser approach_centered_ok). Pan/tilt corrections continue every
+        # frame and trim the ball back toward the gripper aim point even while
+        # we descend, so we don't wait forever for perfect centering.
+        if approach_centered_ok and br < TARGET_RADIUS_PX - RADIUS_TOLERANCE:
+            # Hard ceiling: if we're already at the safety limit, stop approaching.
+            # Prevents table slam when radius_ok never triggers.
+            if pos[SERVO_SHOULDER_LIFT] >= LIFT_MAX or pos[SERVO_ELBOW_FLEX] >= ELBOW_MAX:
+                self._log(f"APPROACH-BLOCKED: lift={pos[SERVO_SHOULDER_LIFT]}>={LIFT_MAX} or elbow={pos[SERVO_ELBOW_FLEX]}>={ELBOW_MAX}; r={int(br)} target={TARGET_RADIUS_PX}")
+            else:
+                d_lift = APPROACH_STEP   # reach forward
+                # Coordinate elbow with shoulder — extends the arm rather than just
+                # tipping the whole thing from the shoulder. Ratio is empirical.
+                d_elbow += int(round(APPROACH_STEP * ELBOW_REACH_RATIO))
+                # Co-trim wrist during descent even when inside CENTER_DEADBAND_PX.
+                # Each lift step shifts the ball ~30 px upward in the frame (5 px per
+                # lift unit measured 2026-04-19), which kicks tilt_err well past the
+                # 60 px deadband and the wrist alone needs 5+ frames to recover —
+                # producing the "descend once every several frames, prefers center=NO"
+                # pattern. Issuing the wrist nudge in the same setPosition as the lift
+                # serializes "descend + recenter" into one command, so the controller
+                # makes net progress every frame instead of ping-ponging.
+                # Pan is NOT co-trimmed: lift/elbow don't shift ball horizontally
+                # much, and a floored MIN_TRIM_STEP_PAN command for a within-deadband
+                # error overshoots the deadband (~126 px shift > 60 px deadband),
+                # causing the same +18/-18 sign-flip oscillation we hit on 2026-04-19.
+                if d_tilt == 0 and tilt_err != 0:
+                    d_tilt = int(round(_step_toward(tilt_err, TILT_GAIN, MAX_STEP))) * TILT_DIR
+
+        if d_pan == 0 and d_tilt == 0 and d_lift == 0 and d_elbow == 0:
+            return annotated
+
+        targets = []
+        if d_pan:
+            new_pan = _clamp(pos[SERVO_SHOULDER_PAN] + d_pan, lo=PAN_MIN, hi=PAN_MAX)
+            targets.append([SERVO_SHOULDER_PAN, new_pan])
+        if d_tilt:
+            new_tilt = _clamp(pos[SERVO_WRIST_FLEX] + d_tilt)
+            targets.append([SERVO_WRIST_FLEX, new_tilt])
+        if d_lift:
+            new_lift = _clamp(pos[SERVO_SHOULDER_LIFT] + d_lift, hi=LIFT_MAX)
+            targets.append([SERVO_SHOULDER_LIFT, new_lift])
+        if d_elbow:
+            new_elbow = _clamp(pos[SERVO_ELBOW_FLEX] + d_elbow, hi=ELBOW_MAX)
+            targets.append([SERVO_ELBOW_FLEX, new_elbow])
+
+        t_arm_start = time.perf_counter()
+        if targets:
+            self._log(f"{self.state}: dpan={d_pan} dtilt={d_tilt} dlift={d_lift} delbow={d_elbow}")
+            try:
+                # wait=False so the camera loop doesn't freeze for ~MOVE_DURATION_MS
+                # while the servo travels. Bus servos accept a new target while a
+                # prior move is in flight — they just retarget smoothly. Each new
+                # frame issues a fresh small correction based on the latest pixel
+                # error, which is what we want.
+                arm.setPosition(targets, duration=MOVE_DURATION_MS, wait=False)
+            except Exception as e:
+                print(f"[ball] setPosition failed: {e}")
+        t_arm = time.perf_counter() - t_arm_start
+        self._perf_n += 1
+        self._perf_detect += t_detect
+        self._perf_arm += t_arm
+        if self._perf_n >= self._perf_every:
+            print(f"[ball-perf] n={self._perf_n}  detect={self._perf_detect/self._perf_n*1000:.1f}ms  "
+                  f"arm={self._perf_arm/self._perf_n*1000:.1f}ms")
+            self._perf_n = 0
+            self._perf_detect = 0.0
+            self._perf_arm = 0.0
+
+        # snapshot state for telemetry
+        self.last_ball = (int(bx), int(by), int(br))
+        self.last_errs = (int(pan_err), int(tilt_err), int(radius_err))
+        self.last_deltas = (int(d_pan), int(d_tilt), int(d_lift), int(d_elbow))
+        self.last_is_prediction = is_prediction
+        self._maybe_send_telemetry(arm, send_telemetry, positions=pos)
+
+        return annotated
+
+    @staticmethod
+    def _largest_blob(mask):
+        """Pick the largest blob that's also round-ish.
+
+        A ball's contour fills its minimum enclosing circle by ~85% or more.
+        Irregular ball-color objects (a logo, a corner of fabric, a shadow
+        edge) typically fill <50% of their enclosing circle even if their
+        raw area is large. The fill_ratio filter rejects those false-positive
+        winners that the area-only check used to accept.
+        """
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        best = None
+        best_area = 0
+        for c in contours:
+            area = cv2.contourArea(c)
+            if area < MIN_CONTOUR_AREA or area <= best_area:
+                continue
+            (x, y), r = cv2.minEnclosingCircle(c)
+            if r <= 0:
+                continue
+            fill_ratio = area / (np.pi * r * r)
+            if fill_ratio < MIN_FILL_RATIO:
+                continue
+            best = (int(x), int(y), float(r))
+            best_area = area
+        return best
+
+    def _do_grab(self, arm):
+        # Open fully, close on the ball, detect stall + relax, then lift and
+        # return home. Home pose deliberately excludes the gripper so the ball
+        # isn't dropped.
+        arm.setPosition(SERVO_GRIPPER, 60, duration=500, wait=True)
+        arm.setPosition(SERVO_GRIPPER, GRIPPER_CLOSE_TARGET, duration=700, wait=True)
+
+        actual = arm.getPosition(SERVO_GRIPPER)
+        if actual < GRIPPER_CLOSE_TARGET - GRIPPER_STALL_SLACK:
+            relaxed = actual + GRIPPER_RELAX_OFFSET
+            print(f"[ball] gripper stalled at {actual} (target {GRIPPER_CLOSE_TARGET}); relaxing to {relaxed}")
+            arm.setPosition(SERVO_GRIPPER, relaxed, duration=200, wait=True)
+            self.hold_target = relaxed
+        else:
+            self.hold_target = GRIPPER_CLOSE_TARGET
+
+        arm.setPosition([
+            [SERVO_SHOULDER_LIFT, 300],
+            [SERVO_ELBOW_FLEX, 350],
+        ], duration=1500, wait=True)
+        arm.setPosition(HOME_POSE_KEEP_GRIP, duration=1800, wait=True)
+
+    def _maybe_predict(self):
+        """Return a (bx, by, br) tuple extrapolated from recent motion, or None.
+
+        On first call after a ball loss, estimates velocity from self.pos_buffer
+        and seeds pred_x/pred_y. Subsequent calls step the prediction forward by
+        the estimated per-frame velocity. Runs for at most MAX_PREDICT_FRAMES.
+        """
+        if not ENABLE_PREDICTION:
+            return None
+        if self.pred_frames_remaining > 0:
+            self.pred_x += self.last_vel[0]
+            self.pred_y += self.last_vel[1]
+            self.pred_frames_remaining -= 1
+            return (int(self.pred_x), int(self.pred_y), self.pred_r)
+
+        if len(self.pos_buffer) < 2:
+            return None
+        fi_old, bx_old, by_old, _ = self.pos_buffer[0]
+        fi_new, bx_new, by_new, br_new = self.pos_buffer[-1]
+        dt = fi_new - fi_old
+        if dt <= 0:
+            return None
+        vx = (bx_new - bx_old) / dt
+        vy = (by_new - by_old) / dt
+        if vx * vx + vy * vy < MIN_VELOCITY_PX_PER_FRAME ** 2:
+            return None
+        # account for frames that have already elapsed since the last real obs
+        frames_since = max(1, self.frame_count - fi_new)
+        self.last_vel = (vx, vy)
+        self.pred_x = bx_new + vx * frames_since
+        self.pred_y = by_new + vy * frames_since
+        self.pred_r = br_new
+        self.pred_frames_remaining = MAX_PREDICT_FRAMES - 1
+        print(f"[ball] predicting: v=({vx:+.1f},{vy:+.1f}) px/frame, {MAX_PREDICT_FRAMES} frames")
+        return (int(self.pred_x), int(self.pred_y), self.pred_r)
+
+    def _maybe_send_telemetry(self, arm, send_telemetry, positions=None):
+        now = time.time()
+        if now - self.last_telemetry_at < TELEMETRY_INTERVAL_S:
+            return
+        try:
+            send_telemetry(arm, extras={"ballTrack": self.telemetry()}, positions=positions)
+            self.last_telemetry_at = now
+        except Exception as e:
+            print(f"[ball] telemetry failed: {e}")
+
+    def get_state(self):
+        return self.state
+
+    def telemetry(self):
+        """Build a flat dict of mode state for IoTConnect telemetry."""
+        bx, by, br = self.last_ball
+        pan_err, tilt_err, radius_err = self.last_errs
+        d_pan, d_tilt, d_lift, d_elbow = self.last_deltas
+        vx, vy = self.last_vel
+        return {
+            "state": self.state,
+            "is_prediction": 1 if self.last_is_prediction else 0,
+            "ball_x": bx,
+            "ball_y": by,
+            "ball_r": br,
+            "pan_err": pan_err,
+            "tilt_err": tilt_err,
+            "radius_err": radius_err,
+            "velocity_x": round(float(vx), 2),
+            "velocity_y": round(float(vy), 2),
+            "pred_frames_left": int(self.pred_frames_remaining),
+            "no_ball_frames": int(self.no_ball_frames),
+            "hold_target": int(self.hold_target) if self.hold_target is not None else 0,
+            "d_pan": d_pan,
+            "d_tilt": d_tilt,
+            "d_lift": d_lift,
+            "d_elbow": d_elbow,
+        }
+
+    def _log(self, msg):
+        if msg != self.last_log:
+            print(f"[ball] {msg}")
+            self.last_log = msg

--- a/renesas-rzg3e-evk/robotic-arm/modes/base.py
+++ b/renesas-rzg3e-evk/robotic-arm/modes/base.py
@@ -1,0 +1,28 @@
+"""Strategy interface for vision modes.
+
+Each mode owns its own model loading, per-frame inference, and arm-control
+decisions. The outer loop in main.py owns the camera, display window, and
+IoTConnect command pump — those are shared across all modes.
+"""
+
+
+class Mode:
+    name = "base"
+
+    def setup(self, arm):
+        """Called once before the camera loop starts. Load models, init state."""
+        return None
+
+    def process_frame(self, frame, arm):
+        """Process one BGR frame. Return an annotated BGR image to display, or None to show frame as-is."""
+        raise NotImplementedError
+
+    def teardown(self, arm):
+        """Called once after the loop exits. Release any mode-owned resources."""
+        return None
+
+    def get_state(self):
+        """Short label for this mode's current state. Published as top-level
+        `state` in /IOTCONNECT telemetry. Override in stateful modes; static
+        modes can return a fixed label (e.g. 'ASL-Gesture')."""
+        return self.name

--- a/renesas-rzg3e-evk/robotic-arm/point_net.py
+++ b/renesas-rzg3e-evk/robotic-arm/point_net.py
@@ -1,0 +1,54 @@
+import torch
+import torch.nn as nn
+
+
+class PointNet(nn.Module):
+    def __init__(self, num_classes):
+        super(PointNet, self).__init__()
+        self.mlp = nn.Sequential(
+            nn.Conv1d(3, 64, 1),
+            nn.BatchNorm1d(64),
+            nn.ReLU(),
+            nn.Conv1d(64, 128, 1),
+            nn.BatchNorm1d(128),
+            nn.ReLU(),
+            nn.Conv1d(128, 1024, 1),
+            nn.BatchNorm1d(1024),
+            nn.ReLU()
+        )
+
+        # Global max pooling over point features
+        self.global_max_pool = nn.MaxPool1d(21)
+
+        # Fully connected layers for classification
+        self.fc_layers = nn.Sequential(
+            nn.Linear(1024, 512),
+            nn.BatchNorm1d(512),
+            nn.ReLU(),
+            nn.Linear(512, 256),
+            nn.BatchNorm1d(256),
+            nn.ReLU(),
+            nn.Linear(256, num_classes)
+        )
+
+    def forward(self, x):
+        # x shape: (batch_size, num_points, num_channels)
+        x = x.permute(0, 2, 1)
+        x = self.mlp(x)
+        x = self.global_max_pool(x)
+        x = x.view(x.size(0), -1)
+        x = self.fc_layers(x)
+        return x
+
+
+if __name__ == '__main__':
+    num_classes = 10
+    model = PointNet(num_classes)
+
+    batch_size = 8
+    num_points = 1024
+    num_channels = 3
+    input_points = torch.randn(batch_size, num_points, num_channels)
+
+    output = model(input_points)
+    print("Output shape:", output.shape)

--- a/renesas-rzg3e-evk/robotic-arm/positions/teach_scan_center.json
+++ b/renesas-rzg3e-evk/robotic-arm/positions/teach_scan_center.json
@@ -1,0 +1,37 @@
+{
+  "timestamp": "2026-04-18T18:26:43Z",
+  "positions": {
+    "shoulder_pan": 491,
+    "shoulder_lift": 369,
+    "elbow_flex": 50,
+    "wrist_flex": 489,
+    "wrist_roll": 498,
+    "gripper": 306
+  },
+  "scan_pose_list": [
+    [
+      6,
+      491
+    ],
+    [
+      5,
+      369
+    ],
+    [
+      4,
+      50
+    ],
+    [
+      3,
+      489
+    ],
+    [
+      2,
+      498
+    ],
+    [
+      1,
+      306
+    ]
+  ]
+}

--- a/renesas-rzg3e-evk/robotic-arm/positions/teach_scan_home.json
+++ b/renesas-rzg3e-evk/robotic-arm/positions/teach_scan_home.json
@@ -1,0 +1,37 @@
+{
+  "timestamp": "2026-04-18T18:31:44Z",
+  "positions": {
+    "shoulder_pan": 505,
+    "shoulder_lift": 127,
+    "elbow_flex": 65508,
+    "wrist_flex": 294,
+    "wrist_roll": 500,
+    "gripper": 306
+  },
+  "scan_pose_list": [
+    [
+      6,
+      505
+    ],
+    [
+      5,
+      127
+    ],
+    [
+      4,
+      65508
+    ],
+    [
+      3,
+      294
+    ],
+    [
+      2,
+      500
+    ],
+    [
+      1,
+      306
+    ]
+  ]
+}

--- a/renesas-rzg3e-evk/robotic-arm/positions/teach_scan_left-edge.json
+++ b/renesas-rzg3e-evk/robotic-arm/positions/teach_scan_left-edge.json
@@ -1,0 +1,37 @@
+{
+  "timestamp": "2026-04-18T18:33:55Z",
+  "positions": {
+    "shoulder_pan": 379,
+    "shoulder_lift": 547,
+    "elbow_flex": 108,
+    "wrist_flex": 379,
+    "wrist_roll": 881,
+    "gripper": 247
+  },
+  "scan_pose_list": [
+    [
+      6,
+      379
+    ],
+    [
+      5,
+      547
+    ],
+    [
+      4,
+      108
+    ],
+    [
+      3,
+      379
+    ],
+    [
+      2,
+      881
+    ],
+    [
+      1,
+      247
+    ]
+  ]
+}

--- a/renesas-rzg3e-evk/robotic-arm/positions/teach_scan_right-edge.json
+++ b/renesas-rzg3e-evk/robotic-arm/positions/teach_scan_right-edge.json
@@ -1,0 +1,37 @@
+{
+  "timestamp": "2026-04-18T18:35:27Z",
+  "positions": {
+    "shoulder_pan": 677,
+    "shoulder_lift": 635,
+    "elbow_flex": 233,
+    "wrist_flex": 434,
+    "wrist_roll": 881,
+    "gripper": 248
+  },
+  "scan_pose_list": [
+    [
+      6,
+      677
+    ],
+    [
+      5,
+      635
+    ],
+    [
+      4,
+      233
+    ],
+    [
+      3,
+      434
+    ],
+    [
+      2,
+      881
+    ],
+    [
+      1,
+      248
+    ]
+  ]
+}

--- a/renesas-rzg3e-evk/robotic-arm/robArm2_template.json
+++ b/renesas-rzg3e-evk/robotic-arm/robArm2_template.json
@@ -1,0 +1,640 @@
+{
+    "code": "robArm4",
+    "name": "robArm4",
+    "authType": 2,
+    "attributes": [
+        {
+            "name": "shoulder_pan",
+            "displayName": "shoulder_pan",
+            "type": "DECIMAL",
+            "description": "Servo 6 position (0-1000); rotates the base left/right.",
+            "unit": "",
+            "attributeColor": "",
+            "aggregateTypes": []
+        },
+        {
+            "name": "shoulder_lift",
+            "displayName": "shoulder_lift",
+            "type": "DECIMAL",
+            "description": "Servo 5 position (0-1000); raises/lowers the upper arm.",
+            "unit": "",
+            "attributeColor": "",
+            "aggregateTypes": []
+        },
+        {
+            "name": "elbow_flex",
+            "displayName": "elbow_flex",
+            "type": "DECIMAL",
+            "description": "Servo 4 position (0-1000); flexes the elbow joint.",
+            "unit": "",
+            "attributeColor": "",
+            "aggregateTypes": []
+        },
+        {
+            "name": "wrist_flex",
+            "displayName": "wrist_flex",
+            "type": "DECIMAL",
+            "description": "Servo 3 position (0-1000); pitches the wrist up/down.",
+            "unit": "",
+            "attributeColor": "",
+            "aggregateTypes": []
+        },
+        {
+            "name": "wrist_roll",
+            "displayName": "wrist_roll",
+            "type": "DECIMAL",
+            "description": "Servo 2 position (0-1000); rotates the wrist clockwise/counter-clockwise.",
+            "unit": "",
+            "attributeColor": "",
+            "aggregateTypes": []
+        },
+        {
+            "name": "gripper",
+            "displayName": "gripper",
+            "type": "DECIMAL",
+            "description": "Servo 1 position (0-1000); 0 = fully open, higher = closed.",
+            "unit": "",
+            "attributeColor": "",
+            "aggregateTypes": []
+        },
+        {
+            "name": "sysInfo_system",
+            "displayName": "",
+            "type": "OBJECT",
+            "description": "Static hardware/OS identification plus host identity and uptime.",
+            "childs": [
+                {
+                    "name": "hostname",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Device hostname.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "uptime",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Human-readable system uptime since boot.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "cpu_brand",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "CPU brand string (e.g. Cortex-A55).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "cpu_vendor",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "CPU vendor (e.g. ARM).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "cpu_mhz",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Advertised clock speed in MHz.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "cpu_physical_cores",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Physical core count.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "architecture",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Machine architecture (e.g. aarch64).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "system",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Operating system name (e.g. Linux).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "release",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Kernel release string.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "platform",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Full platform descriptor.",
+                    "unit": "",
+                    "attributeColor": ""
+                }
+            ],
+            "aggregateTypes": []
+        },
+        {
+            "name": "sysInfo_cpu",
+            "displayName": "",
+            "type": "OBJECT",
+            "description": "CPU utilization, temperature, and the top CPU-consuming process.",
+            "childs": [
+                {
+                    "name": "usage_percent",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "Overall CPU utilization across all cores.",
+                    "unit": "%",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "temp",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "Hottest CPU thermal zone (max of cpu*-thermal sensors).",
+                    "unit": "C",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "top_process_name",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Process name with the highest CPU usage.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "top_process_cmd",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Full command line of the top CPU process (truncated to 100 chars).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "top_process_cpu_percent",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "CPU usage of the top process.",
+                    "unit": "%",
+                    "attributeColor": ""
+                }
+            ],
+            "aggregateTypes": []
+        },
+        {
+            "name": "sysInfo_memory",
+            "displayName": "",
+            "type": "OBJECT",
+            "description": "RAM utilization, temperature, and the top memory-consuming process.",
+            "childs": [
+                {
+                    "name": "percent",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "Memory utilization percentage.",
+                    "unit": "%",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "temp",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "DDR memory thermal zone (ddr-thermal sensor).",
+                    "unit": "C",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "total",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Total physical memory (formatted, e.g. 7.20GB).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "available",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Memory available to start new applications (formatted).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "used",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Memory currently in use (formatted).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "top_process_name",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Process name holding the most RAM.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "top_process_cmd",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Full command line of the top memory process (truncated to 100 chars).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "top_process_mem",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Resident set size of the top memory process (formatted).",
+                    "unit": "",
+                    "attributeColor": ""
+                }
+            ],
+            "aggregateTypes": []
+        },
+        {
+            "name": "sysInfo_storage",
+            "displayName": "",
+            "type": "OBJECT",
+            "description": "Disk usage for the root filesystem.",
+            "childs": [
+                {
+                    "name": "total",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Total disk capacity (formatted, e.g. 52.65GB).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "used",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Disk space used (formatted).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "free",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "Disk space free (formatted).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "percent",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "Disk utilization percentage.",
+                    "unit": "%",
+                    "attributeColor": ""
+                }
+            ],
+            "aggregateTypes": []
+        },
+        {
+            "name": "sysInfo_gpu",
+            "displayName": "",
+            "type": "OBJECT",
+            "description": "Adreno GPU utilization and temperature.",
+            "childs": [
+                {
+                    "name": "usage_percent",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "Adreno GPU busy percentage from /sys/class/kgsl/kgsl-3d0/gpubusy.",
+                    "unit": "%",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "temp",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "Hottest GPU thermal zone (max of gpuss*-thermal sensors).",
+                    "unit": "C",
+                    "attributeColor": ""
+                }
+            ],
+            "aggregateTypes": []
+        },
+        {
+            "name": "ballTrack",
+            "displayName": "",
+            "type": "OBJECT",
+            "description": "Ball-follow mode runtime state (tracking, prediction, servo deltas).",
+            "childs": [
+                {
+                    "name": "state",
+                    "displayName": "",
+                    "type": "STRING",
+                    "description": "IDLE | TRACKING | PREDICTING | GRABBING | HOLDING.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "is_prediction",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "1 when ball position is extrapolated from velocity (not seen this frame).",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "ball_x",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Ball center X in camera pixels (original, unmirrored frame).",
+                    "unit": "px",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "ball_y",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Ball center Y in camera pixels.",
+                    "unit": "px",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "ball_r",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Ball apparent radius in pixels.",
+                    "unit": "px",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "pan_err",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Horizontal error: ball x minus frame center x.",
+                    "unit": "px",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "tilt_err",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Vertical error: ball y minus frame center y.",
+                    "unit": "px",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "radius_err",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Distance error: target radius minus current radius.",
+                    "unit": "px",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "velocity_x",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "Estimated horizontal ball velocity in pixels per frame.",
+                    "unit": "px/f",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "velocity_y",
+                    "displayName": "",
+                    "type": "DECIMAL",
+                    "description": "Estimated vertical ball velocity in pixels per frame.",
+                    "unit": "px/f",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "pred_frames_left",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Prediction frames remaining before we give up and recenter.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "no_ball_frames",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Consecutive frames with no ball detected and no active prediction.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "hold_target",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Gripper position being held; 0 when not holding.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "d_pan",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Last commanded shoulder_pan delta.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "d_tilt",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Last commanded wrist_flex delta.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "d_lift",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Last commanded shoulder_lift delta.",
+                    "unit": "",
+                    "attributeColor": ""
+                },
+                {
+                    "name": "d_elbow",
+                    "displayName": "",
+                    "type": "INTEGER",
+                    "description": "Last commanded elbow_flex delta.",
+                    "unit": "",
+                    "attributeColor": ""
+                }
+            ],
+            "aggregateTypes": []
+        }
+    ],
+    "commands": [
+        {
+            "name": "move_left",
+            "command": "move_left",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "move_right",
+            "command": "move_right",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "move_up",
+            "command": "move_up",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "move_down",
+            "command": "move_down",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "move_forward",
+            "command": "move_forward",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "move_backward",
+            "command": "move_backward",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "move_to",
+            "command": "move_to",
+            "requiredParam": true,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "move_to_home",
+            "command": "move_to_home",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "open_gripper",
+            "command": "open_gripper",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "close_gripper",
+            "command": "close_gripper",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "wrist_roll_cw",
+            "command": "wrist_roll_cw",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "wrist_roll_ccw",
+            "command": "wrist_roll_ccw",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "wrist_flex_up",
+            "command": "wrist_flex_up",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "wrist_flex_down",
+            "command": "wrist_flex_down",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "demo_wave",
+            "command": "demo_wave",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "demo_bow",
+            "command": "demo_bow",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "demo_stretch",
+            "command": "demo_stretch",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "demo_scan",
+            "command": "demo_scan",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "demo_shake_no",
+            "command": "demo_shake_no",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        },
+        {
+            "name": "demo_pickup",
+            "command": "demo_pickup",
+            "requiredParam": false,
+            "requiredAck": true,
+            "isOTACommand": false
+        }
+    ],
+    "messageVersion": "2.1",
+    "msgCode": "XG4EVRY",
+    "capability": "0",
+    "enableCSR": "false",
+    "c2dOnDemand": 0,
+    "properties": {
+        "description": null,
+        "dataFrequency": "5",
+        "fileSupport": false,
+        "certRenewalDay": 0,
+        "enableCSR": false
+    },
+    "_meta": {
+        "version": "2.0"
+    }
+}

--- a/renesas-rzg3e-evk/robotic-arm/scripts/deps-download.sh
+++ b/renesas-rzg3e-evk/robotic-arm/scripts/deps-download.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Download all wheels needed by the robotic-arm demo on the RZ/G3E and scp
+# them to the board, then transfer the demo source. The base RZ/G3E image
+# does not ship pip repositories, so dependencies are fetched on the host
+# (where pip can reach PyPI) and installed offline on the board.
+#
+# Usage: bash deps-download.sh <board-ip-address>
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <board-ip-address>"
+    echo "Example: $0 192.168.1.100"
+    exit 1
+fi
+
+BOARD_IP=$1
+WORK_DIR="/tmp/iotc-robotic-arm-packages"
+DEMO_REPO_URL="https://github.com/avnet-iotconnect/iotc-python-lite-sdk-demos.git"
+DEMO_REL_PATH="renesas-rzg3e-evk/robotic-arm"
+
+echo ""
+echo "Board IP: $BOARD_IP"
+echo "Working directory: $WORK_DIR"
+echo ""
+
+mkdir -p "$WORK_DIR"
+cd "$WORK_DIR"
+
+# Wheels for the arm + vision pipeline. Targeting the RZ/G3E's CPython on
+# linux_aarch64 (manylinux2014). torch / mediapipe are best-effort: if no
+# matching wheel exists pip will skip them and the ASL mode will be
+# unavailable on the board (ball mode still runs).
+#
+# PY_VER must match the board's `python3 --version` (the shipped image
+# uses Python 3.12). Override at the command line if your image differs:
+#   PY_VER=cp311 bash deps-download.sh <ip>
+PY_VER="${PY_VER:-cp312}"
+PLATFORM="manylinux2014_aarch64"
+
+# psutil + py-cpuinfo are intentionally excluded: the RZ/G3E's Yocto
+# python image strips the `resource` and `multiprocessing` stdlib
+# modules, which both libraries import at top level. systemdata.py
+# reads /proc and /sys directly, so neither is needed.
+REQUIRED=(
+    "xarm>=0.0.4"
+    "hidapi>=0.14"
+    "opencv-python-headless>=4.5.0"
+    "numpy>=1.21.0"
+    "requests>=2.25.0"
+)
+
+OPTIONAL=(
+    "torch>=1.9.0"
+    "torchvision>=0.10.0"
+    "mediapipe>=0.8.0"
+)
+
+echo "Downloading required wheels (arm + ball-follow)..."
+pip3 download \
+    --only-binary=:all: \
+    --platform "$PLATFORM" \
+    --python-version "${PY_VER#cp}" \
+    --implementation cp \
+    --abi "$PY_VER" \
+    -d "$WORK_DIR" \
+    "${REQUIRED[@]}"
+
+echo ""
+echo "Attempting optional wheels (ASL mode — torch / mediapipe)..."
+for pkg in "${OPTIONAL[@]}"; do
+    if ! pip3 download \
+        --only-binary=:all: \
+        --platform "$PLATFORM" \
+        --python-version "${PY_VER#cp}" \
+        --implementation cp \
+        --abi "$PY_VER" \
+        -d "$WORK_DIR" \
+        "$pkg" 2>/dev/null; then
+        echo "  - SKIPPED: no aarch64 wheel for '$pkg' (ASL mode will be unavailable)"
+    fi
+done
+
+echo ""
+echo "Checking out demo source..."
+if [ -d "iotc-python-lite-sdk-demos" ]; then
+    (cd iotc-python-lite-sdk-demos && git pull)
+else
+    git clone --depth 1 "$DEMO_REPO_URL"
+fi
+
+echo ""
+echo "Transferring wheels to board..."
+scp "$WORK_DIR"/*.whl root@"$BOARD_IP":~
+
+echo ""
+echo "Transferring demo source to board (~/robotic-arm)..."
+scp -r "$WORK_DIR/iotc-python-lite-sdk-demos/$DEMO_REL_PATH" root@"$BOARD_IP":~/robotic-arm
+
+echo ""
+echo "Done. On the board, run:"
+echo "  bash ~/robotic-arm/scripts/deps-install.sh"

--- a/renesas-rzg3e-evk/robotic-arm/scripts/deps-install.sh
+++ b/renesas-rzg3e-evk/robotic-arm/scripts/deps-install.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Install the robotic-arm demo dependencies on the RZ/G3E from wheels that
+# were transferred by deps-download.sh on the host PC. The base RZ/G3E
+# image lacks pip repositories, so this script unzips each wheel directly
+# into the system site-packages — the same pattern used by the base
+# renesas-rzg3e-evk dependency installer.
+
+set -e
+
+SITE_PACKAGES=$(python3 -c "import sys; print([p for p in sys.path if 'site-packages' in p][0])")
+
+cd ~
+installed=0
+skipped=0
+for wheel in *.whl; do
+    if [ ! -f "$wheel" ]; then
+        continue
+    fi
+    echo "  - Installing $wheel..."
+    if unzip -o "$wheel" -d "$SITE_PACKAGES/" > /dev/null 2>&1; then
+        installed=$((installed + 1))
+    else
+        echo "    SKIPPED: failed to unpack $wheel"
+        skipped=$((skipped + 1))
+    fi
+done
+
+echo ""
+echo "Wheels installed: $installed (skipped: $skipped)"
+
+# Move into the demo directory and download the ASL model file (no-op if
+# torch/mediapipe weren't installable — the file just won't be used).
+DEMO_DIR=~/robotic-arm
+if [ -d "$DEMO_DIR/model" ]; then
+    echo ""
+    echo "Fetching ASL model into $DEMO_DIR/model ..."
+    (cd "$DEMO_DIR/model" && bash ./get_model.sh) || \
+        echo "  (model download skipped or failed — ASL mode will not run)"
+fi
+
+# Sanity check what's available so the operator knows which mode will work.
+echo ""
+echo "Module availability check:"
+for mod in cv2 numpy xarm hid avnet.iotconnect.sdk.lite torch mediapipe; do
+    if python3 -c "import $mod" 2>/dev/null; then
+        echo "  OK    : $mod"
+    else
+        echo "  MISS  : $mod"
+    fi
+done
+
+echo ""
+echo "Done. The demo lives at $DEMO_DIR — see its README for run instructions."

--- a/renesas-rzg3e-evk/robotic-arm/start.sh
+++ b/renesas-rzg3e-evk/robotic-arm/start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Launch the IoTConnect XArm vision demo on the Renesas RZ/G3E EVK.
+# The base RZ/G3E image uses system python3 (no conda), so this is
+# stripped down compared to the TRIA variant.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+LOG="$SCRIPT_DIR/run.log"
+echo "===== START $(date -u +%FT%TZ) =====" | tee "$LOG"
+echo "Logging to $LOG" | tee -a "$LOG"
+
+# python3 -u gives unbuffered I/O on its own (the busybox image used by the
+# RZ/G3E doesn't ship stdbuf, and python -u is sufficient for line-buffered
+# log output via tee).
+exec python3 -u main.py "$@" 2>&1 | tee -a "$LOG"

--- a/renesas-rzg3e-evk/robotic-arm/sweep_limits.py
+++ b/renesas-rzg3e-evk/robotic-arm/sweep_limits.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Discover per-servo mechanical limits on the Hiwonder xArm 1S.
+
+For each servo, starts at 500 and steps slowly toward 0, then back to 500, then
+toward 1000. At each step it commands a position, waits, then reads back the
+actual position. If the read-back stops following the command (stall against a
+mechanical stop), that direction is considered done.
+
+Ctrl-C at any time returns the arm to home (all 500s) and exits. Also pauses
+between servos so you can reposition the arm, clear obstacles, or skip a joint.
+
+Run from the HDMI terminal or over SSH — it does not need a display.
+"""
+
+import json
+import os
+import signal
+import sys
+import time
+
+import xarm
+
+LIMITS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "arm_limits.json")
+
+STEP = 40                  # servo units per step (~10 deg)
+SETTLE_S = 0.35            # seconds to wait for servo to reach commanded pos
+STALL_GAP = 60             # if |commanded - actual| > this for 2 steps, stalled
+MOVE_DURATION_MS = 400     # servo move duration per step
+SERVOS = [
+    (6, "shoulder_pan"),
+    (5, "shoulder_lift"),
+    (4, "elbow_flex"),
+    (3, "wrist_flex"),
+    (2, "wrist_roll"),
+    (1, "gripper"),
+]
+
+arm = None
+
+
+def goto(servo_id, pos):
+    arm.setPosition(servo_id, pos, duration=MOVE_DURATION_MS, wait=True)
+    time.sleep(SETTLE_S)
+    return arm.getPosition(servo_id)
+
+
+def sweep_direction(servo_id, direction):
+    """direction is +1 (toward 1000) or -1 (toward 0). Returns last non-stalled commanded pos."""
+    cmd = 500
+    last_good = 500
+    consecutive_stalls = 0
+    while 0 <= cmd + direction * STEP <= 1000:
+        cmd += direction * STEP
+        actual = goto(servo_id, cmd)
+        gap = abs(cmd - actual)
+        print(f"  cmd={cmd:4d}  actual={actual:4d}  gap={gap:3d}")
+        if gap > STALL_GAP:
+            consecutive_stalls += 1
+            if consecutive_stalls >= 2:
+                print(f"  -> stall at cmd={cmd}, last_good={last_good}")
+                return last_good
+        else:
+            consecutive_stalls = 0
+            last_good = cmd
+    print(f"  -> hit library bound, last_good={last_good}")
+    return last_good
+
+
+def home_all():
+    print("Homing all servos to 500...")
+    positions = [[i, 500] for i in range(1, 7)]
+    arm.setPosition(positions, duration=1500, wait=True)
+    time.sleep(0.6)
+
+
+def cleanup(signum=None, frame=None):
+    print("\nInterrupted. Returning to home and turning servos off.")
+    try:
+        home_all()
+    except Exception:
+        pass
+    try:
+        arm.servoOff()
+    except Exception:
+        pass
+    sys.exit(0)
+
+
+def main():
+    global arm
+    print("Connecting to xArm...")
+    arm = xarm.Controller('USB')
+    signal.signal(signal.SIGINT, cleanup)
+
+    home_all()
+
+    limits = {}
+    for servo_id, name in SERVOS:
+        print(f"\n=== Servo {servo_id} ({name}) ===")
+        ans = input("Press Enter to sweep, or 's' to skip: ").strip().lower()
+        if ans == 's':
+            continue
+
+        print(f"Sweeping {name} down toward 0...")
+        low = sweep_direction(servo_id, -1)
+        goto(servo_id, 500)
+
+        print(f"Sweeping {name} up toward 1000...")
+        high = sweep_direction(servo_id, +1)
+        goto(servo_id, 500)
+
+        limits[name] = (low, high)
+        print(f"{name}: safe range ≈ [{low}, {high}]  (~{(high-low)*0.24:.0f}° total)")
+
+    home_all()
+    arm.servoOff()
+
+    print("\n===== SUMMARY =====")
+    summary = {}
+    for (servo_id, name), (low, high) in (
+        (k, limits[k[1]]) for k in SERVOS if k[1] in limits
+    ):
+        deg = (high - low) * 0.24
+        print(f"  servo {servo_id} {name:15s}  [{low:4d}, {high:4d}]  ~{deg:5.1f}°")
+        summary[name] = {"servo_id": servo_id, "min": low, "max": high, "range_deg": round(deg, 1)}
+
+    with open(LIMITS_FILE, "w") as f:
+        json.dump({"timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "servos": summary}, f, indent=2)
+    print(f"\nSaved limits to {LIMITS_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/renesas-rzg3e-evk/robotic-arm/systemdata.py
+++ b/renesas-rzg3e-evk/robotic-arm/systemdata.py
@@ -1,0 +1,433 @@
+"""System telemetry collector — stdlib + /proc/sys only.
+
+The TRIA build of this file used psutil + py-cpuinfo, but the RZ/G3E's
+Yocto Python image strips ``resource`` and ``multiprocessing`` from the
+stdlib, which breaks both packages. This rewrite reads the same data
+directly from /proc and /sys so the demo runs on minimal embedded
+images. The public dataclasses and ``collect_data()`` shape are
+unchanged so main.py doesn't need to care."""
+
+import glob
+import json
+import os
+import platform
+import re
+import time
+from dataclasses import dataclass, asdict
+
+
+@dataclass(frozen=True)
+class CpuUtilization:
+    usage_percent: float
+    top_process_name: str
+    top_process_cmd: str
+    top_process_cpu_percent: float
+
+
+@dataclass(frozen=True)
+class MemoryInfo:
+    total: str
+    available: str
+    used: str
+    percent: float
+    top_process_name: str
+    top_process_cmd: str
+    top_process_mem: str
+
+
+@dataclass(frozen=True)
+class StorageInfo:
+    total: str
+    used: str
+    free: str
+    percent: float
+
+
+@dataclass(frozen=True)
+class SystemInfo:
+    cpu_brand: str
+    cpu_vendor: str
+    cpu_mhz: str
+    cpu_physical_cores: int
+    architecture: str
+    system: str
+    release: str
+    platform: str
+
+
+@dataclass(frozen=True)
+class SystemData:
+    uptime: str
+    system_info: SystemInfo
+    cpu: CpuUtilization
+    memory: MemoryInfo
+    storage: StorageInfo
+    hostname: str
+    cpu_temp: float       # max of all cpu*-thermal zones, °C
+    gpu_temp: float       # max of gpu*-thermal zones, °C (0.0 if none)
+    memory_temp: float    # ddr/mem-thermal zone, °C (0.0 if none)
+    gpu_usage: float      # GPU busy %, currently QCS6490-only via kgsl
+
+
+def format_bytes(size_in_bytes) -> str:
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(size_in_bytes)
+    for unit in units:
+        if size < 1024:
+            return f"{size:.2f}{unit}"
+        size /= 1024
+    return f"{size:.2f}{units[-1]}"
+
+
+def to_display_time(seconds, granularity=2) -> str:
+    intervals = (
+        ('weeks', 604800),
+        ('days', 86400),
+        ('hours', 3600),
+        ('minutes', 60),
+        ('seconds', 1),
+    )
+    result = []
+    for name, count in intervals:
+        value = seconds // count
+        if value:
+            seconds -= value * count
+            if value == 1:
+                name = name.rstrip('s')
+            result.append(f"{int(value)} {name}")
+    return ', '.join(result[:granularity])
+
+
+def _read_text(path, default=""):
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except OSError:
+        return default
+
+
+def _read_int_file(path):
+    try:
+        with open(path) as f:
+            return int(f.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _read_uptime():
+    return float(_read_text('/proc/uptime', '0').split()[0] or 0)
+
+
+def _read_meminfo():
+    info = {}
+    try:
+        with open('/proc/meminfo') as f:
+            for line in f:
+                k, _, v = line.partition(':')
+                parts = v.strip().split()
+                if parts and parts[0].isdigit():
+                    info[k] = int(parts[0]) * 1024  # values are in kB
+    except OSError:
+        pass
+    return info
+
+
+def _read_cpu_jiffies():
+    """Total + idle jiffies from the aggregate 'cpu' line of /proc/stat."""
+    try:
+        with open('/proc/stat') as f:
+            line = f.readline()
+    except OSError:
+        return 0, 0
+    parts = line.split()[1:]  # skip the 'cpu' header
+    nums = [int(x) for x in parts]
+    if len(nums) < 4:
+        return 0, 0
+    idle = nums[3]
+    total = sum(nums)
+    return total, idle
+
+
+def _logical_cpu_count():
+    return len(glob.glob('/sys/devices/system/cpu/cpu[0-9]*'))
+
+
+def _physical_cpu_count():
+    """Distinct (physical_id, core_id) pairs from /proc/cpuinfo. ARM kernels
+    often omit these fields, in which case we fall back to the logical count."""
+    pairs = set()
+    cur = {}
+    try:
+        with open('/proc/cpuinfo') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    if 'physical id' in cur and 'core id' in cur:
+                        pairs.add((cur['physical id'], cur['core id']))
+                    cur = {}
+                    continue
+                if ':' in line:
+                    k, _, v = line.partition(':')
+                    cur[k.strip()] = v.strip()
+            if 'physical id' in cur and 'core id' in cur:
+                pairs.add((cur['physical id'], cur['core id']))
+    except OSError:
+        pass
+    return len(pairs) or _logical_cpu_count()
+
+
+def _cpu_brand():
+    """Best-effort human-readable CPU label.
+
+    /proc/cpuinfo has 'model name' on x86 but not on most ARM kernels;
+    /proc/device-tree/model carries the SoC/board name on device-tree
+    platforms; otherwise we decode the ARM implementer + part."""
+    try:
+        with open('/proc/cpuinfo') as f:
+            for line in f:
+                k, _, v = line.partition(':')
+                if k.strip() == 'model name':
+                    return v.strip()
+    except OSError:
+        pass
+
+    dt_model = _read_text('/proc/device-tree/model').rstrip('\x00')
+    if dt_model:
+        return dt_model
+
+    impl = part = None
+    try:
+        with open('/proc/cpuinfo') as f:
+            for line in f:
+                k, _, v = line.partition(':')
+                k = k.strip()
+                if k == 'CPU implementer':
+                    impl = v.strip()
+                elif k == 'CPU part':
+                    part = v.strip()
+                if impl and part:
+                    break
+    except OSError:
+        pass
+    arm_parts = {'0xd03': 'Cortex-A53', '0xd05': 'Cortex-A55',
+                 '0xd07': 'Cortex-A57', '0xd08': 'Cortex-A72',
+                 '0xd09': 'Cortex-A73', '0xd0a': 'Cortex-A75',
+                 '0xd0b': 'Cortex-A76', '0xd44': 'Cortex-A78'}
+    if impl == '0x41' and part in arm_parts:
+        return f"ARM {arm_parts[part]}"
+    return platform.processor() or platform.machine() or 'unknown'
+
+
+def _cpu_vendor():
+    try:
+        with open('/proc/cpuinfo') as f:
+            for line in f:
+                k, _, v = line.partition(':')
+                if k.strip() == 'vendor_id':
+                    return v.strip()
+    except OSError:
+        pass
+    impl = None
+    try:
+        with open('/proc/cpuinfo') as f:
+            for line in f:
+                k, _, v = line.partition(':')
+                if k.strip() == 'CPU implementer':
+                    impl = v.strip()
+                    break
+    except OSError:
+        pass
+    return {'0x41': 'ARM', '0x4e': 'NVIDIA', '0x51': 'Qualcomm'}.get(impl, 'unknown')
+
+
+def _cpu_mhz():
+    """cpu0 max frequency in MHz, falling back to /proc/cpuinfo's 'cpu MHz'."""
+    khz = _read_int_file('/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq')
+    if khz:
+        return str(int(khz / 1000))
+    try:
+        with open('/proc/cpuinfo') as f:
+            for line in f:
+                k, _, v = line.partition(':')
+                if k.strip() == 'cpu MHz':
+                    return str(int(float(v.strip())))
+    except OSError:
+        pass
+    return 'N/A'
+
+
+def get_system_info():
+    return SystemInfo(
+        cpu_physical_cores=_physical_cpu_count(),
+        cpu_brand=_cpu_brand(),
+        cpu_vendor=_cpu_vendor(),
+        cpu_mhz=_cpu_mhz(),
+        architecture=platform.machine(),
+        system=platform.system(),
+        release=platform.release(),
+        platform=platform.platform()
+    )
+
+
+def _iter_processes():
+    """Yield (pid_dir, comm, cmdline, jiffies, vmrss_bytes) for every process
+    in /proc. Silently skips entries that disappear or refuse access."""
+    for pid_dir in glob.glob('/proc/[0-9]*'):
+        try:
+            stat = _read_text(f'{pid_dir}/stat')
+            if not stat:
+                continue
+            l = stat.index('(')
+            r = stat.rindex(')')
+            comm = stat[l + 1:r]
+            fields = stat[r + 2:].split()
+            jiffies = int(fields[11]) + int(fields[12])  # utime + stime
+        except (ValueError, IndexError):
+            continue
+        cmdline = _read_text(f'{pid_dir}/cmdline').replace('\x00', ' ').strip() or comm
+        rss = 0
+        try:
+            with open(f'{pid_dir}/status') as f:
+                for line in f:
+                    if line.startswith('VmRSS:'):
+                        parts = line.split()
+                        if len(parts) >= 2 and parts[1].isdigit():
+                            rss = int(parts[1]) * 1024
+                        break
+        except OSError:
+            pass
+        yield pid_dir, comm, cmdline, jiffies, rss
+
+
+def get_cpu_usage_percent(interval=0.5):
+    """Aggregate CPU usage across all cores between two /proc/stat samples."""
+    t1, i1 = _read_cpu_jiffies()
+    time.sleep(interval)
+    t2, i2 = _read_cpu_jiffies()
+    dt = t2 - t1
+    if dt <= 0:
+        return 0.0
+    return round((1.0 - (i2 - i1) / dt) * 100, 1)
+
+
+def get_top_cpu_process(interval=0.5):
+    """Sample /proc twice ``interval`` apart, return the process with the
+    largest jiffy delta. Returns (name, cmd, percent_of_one_core)."""
+    snap1 = {pid_dir: ticks for pid_dir, _, _, ticks, _ in _iter_processes()}
+    time.sleep(interval)
+    best_name = "N/A"
+    best_cmd = "N/A"
+    best_delta = 0
+    for pid_dir, comm, cmdline, ticks2, _rss in _iter_processes():
+        delta = ticks2 - snap1.get(pid_dir, ticks2)
+        if delta > best_delta:
+            best_delta = delta
+            best_name = comm
+            best_cmd = cmdline
+    try:
+        clk_tck = os.sysconf('SC_CLK_TCK')
+    except (ValueError, OSError):
+        clk_tck = 100
+    pct = round(best_delta / (clk_tck * interval) * 100, 1) if best_delta > 0 else 0.0
+    return best_name, best_cmd[:100], pct
+
+
+def get_top_memory_process():
+    best_name = "N/A"
+    best_cmd = "N/A"
+    best_mem = 0
+    for _pid_dir, comm, cmdline, _jiffies, rss in _iter_processes():
+        if rss > best_mem:
+            best_mem = rss
+            best_name = comm
+            best_cmd = cmdline
+    return best_name, best_cmd[:100], format_bytes(best_mem)
+
+
+def _disk_usage(path='/'):
+    try:
+        st = os.statvfs(path)
+    except OSError:
+        return 0, 0, 0, 0.0
+    total = st.f_blocks * st.f_frsize
+    free = st.f_bavail * st.f_frsize
+    used = total - st.f_bfree * st.f_frsize
+    pct = round((used / total) * 100, 1) if total > 0 else 0.0
+    return total, used, free, pct
+
+
+def _max_thermal_celsius(type_regex):
+    """Return the highest temperature in °C across thermal_zones whose
+    `type` matches the regex. Returns 0.0 if no zone matches."""
+    pattern = re.compile(type_regex)
+    best = None
+    for zone in glob.glob('/sys/class/thermal/thermal_zone*'):
+        zone_type = _read_text(os.path.join(zone, 'type'))
+        if not pattern.match(zone_type):
+            continue
+        temp_mc = _read_int_file(os.path.join(zone, 'temp'))
+        if temp_mc is None:
+            continue
+        if best is None or temp_mc > best:
+            best = temp_mc
+    return round(best / 1000.0, 1) if best is not None else 0.0
+
+
+def get_gpu_usage_percent():
+    """Adreno GPU busy %. Returns 0.0 on boards without /sys/class/kgsl."""
+    try:
+        with open('/sys/class/kgsl/kgsl-3d0/gpubusy') as f:
+            parts = f.read().strip().split()
+        busy, total = int(parts[0]), int(parts[1])
+        if total <= 0:
+            return 0.0
+        return round(min(100.0, busy * 100.0 / total), 1)
+    except (OSError, ValueError, IndexError):
+        return 0.0
+
+
+def collect_data() -> SystemData:
+    cpu_pct_total = get_cpu_usage_percent()
+    cpu_name, cpu_cmd, cpu_pct = get_top_cpu_process()
+    mem_name, mem_cmd, mem_used_str = get_top_memory_process()
+    mem = _read_meminfo()
+    total = mem.get('MemTotal', 0)
+    available = mem.get('MemAvailable', mem.get('MemFree', 0))
+    used = max(0, total - available)
+    mem_pct = round((used / total) * 100, 1) if total > 0 else 0.0
+    disk_total, disk_used, disk_free, disk_pct = _disk_usage('/')
+
+    return SystemData(
+        uptime=to_display_time(_read_uptime()),
+        system_info=get_system_info(),
+        cpu=CpuUtilization(
+            usage_percent=cpu_pct_total,
+            top_process_name=cpu_name,
+            top_process_cmd=cpu_cmd,
+            top_process_cpu_percent=cpu_pct,
+        ),
+        memory=MemoryInfo(
+            total=format_bytes(total),
+            available=format_bytes(available),
+            used=format_bytes(used),
+            percent=mem_pct,
+            top_process_name=mem_name,
+            top_process_cmd=mem_cmd,
+            top_process_mem=mem_used_str,
+        ),
+        storage=StorageInfo(
+            total=format_bytes(disk_total),
+            used=format_bytes(disk_used),
+            free=format_bytes(disk_free),
+            percent=disk_pct,
+        ),
+        hostname=os.uname().nodename,
+        cpu_temp=_max_thermal_celsius(r'^cpu\d*[-_]?thermal$'),
+        gpu_temp=_max_thermal_celsius(r'^gpu\w*[-_]?thermal$'),
+        memory_temp=_max_thermal_celsius(r'^(ddr|mem|memory)[-_]?thermal$'),
+        gpu_usage=get_gpu_usage_percent(),
+    )
+
+
+if __name__ == "__main__":
+    print(json.dumps(asdict(collect_data())))

--- a/renesas-rzg3e-evk/robotic-arm/teach.sh
+++ b/renesas-rzg3e-evk/robotic-arm/teach.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Pose the arm by hand, snapshot scan poses, and print SCAN_POSE blocks
+# to paste into modes/ball_follow.py.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+exec python3 -u teach_pose.py "$@"

--- a/renesas-rzg3e-evk/robotic-arm/teach_pose.py
+++ b/renesas-rzg3e-evk/robotic-arm/teach_pose.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Teach mode: turn off servo torque so the arm can be posed by hand,
+then continuously print the current servo positions.
+
+Workflow:
+  1. SUPPORT THE ARM with your hand before continuing — it will fall when
+     torque drops, and a wall/ceiling-mounted arm will swing freely.
+  2. Press Enter to disable torque.
+  3. Move the arm into the pose you want (camera pointing where you want it).
+  4. Hold it still; the printed line that stays stable IS the pose.
+  5. Press 's' + Enter to snapshot the current pose to teach_pose.json.
+  6. Press 'h' + Enter to re-enable torque (arm will hold its current pose).
+  7. Ctrl-C to exit (re-enables torque first as a safety).
+"""
+
+import json
+import os
+import signal
+import sys
+import threading
+import time
+
+import xarm
+from xarm import Servo
+
+OUT_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "teach_pose.json")
+
+SERVOS = [
+    (6, "shoulder_pan"),
+    (5, "shoulder_lift"),
+    (4, "elbow_flex"),
+    (3, "wrist_flex"),
+    (2, "wrist_roll"),
+    (1, "gripper"),
+]
+
+# Reusable Servo objects for batched read — single USB round-trip for all 6.
+_ALL_SERVOS = [Servo(sid) for sid, _ in SERVOS]
+_NAME_BY_ID = {sid: name for sid, name in SERVOS}
+
+arm = None
+torque_on = True
+running = True
+last_positions = {}
+
+# Guards USB access so the reader thread can't clash with snapshot/hold ops.
+_bus_lock = threading.Lock()
+
+
+def read_all():
+    """Batched read of all servo positions in a single USB round-trip."""
+    try:
+        with _bus_lock:
+            arm.getPosition(_ALL_SERVOS)
+        return {_NAME_BY_ID[s.servo_id]: int(s.position) for s in _ALL_SERVOS}
+    except Exception as e:
+        return {name: f"ERR({e})" for _, name in SERVOS}
+
+
+def hold_current_pose():
+    """Re-enable torque by commanding each servo to its current measured position.
+
+    Batched read + longer move duration avoids the drift+jerk that a per-servo
+    read-then-write sequence produces (6 sequential reads take ~60-100 ms, during
+    which gravity pulls the arm past the first servo's captured position).
+    """
+    with _bus_lock:
+        try:
+            arm.getPosition(_ALL_SERVOS)
+        except Exception as e:
+            print(f"[teach] batched read failed: {e}")
+            return
+        targets = [[s.servo_id, int(s.position)] for s in _ALL_SERVOS]
+        # Slow move so any small read-to-command drift is absorbed smoothly
+        # rather than snapping in 300 ms.
+        arm.setPosition(targets, duration=1500, wait=True)
+
+
+def cleanup(signum=None, frame=None):
+    global running
+    running = False
+    print("\n[teach] re-enabling torque at current pose for safety...")
+    try:
+        hold_current_pose()
+    except Exception as e:
+        print(f"[teach] hold failed: {e}")
+    sys.exit(0)
+
+
+def reader_loop():
+    global last_positions
+    while running:
+        last_positions = read_all()
+        line = "  ".join(f"{n}={last_positions[n]:>4}" if isinstance(last_positions[n], int)
+                         else f"{n}={last_positions[n]}"
+                         for _, n in SERVOS)
+        print(f"[teach] {line}", flush=True)
+        time.sleep(0.5)
+
+
+def save_snapshot():
+    snap = {n: last_positions.get(n) for _, n in SERVOS}
+    payload = {"timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+               "positions": snap,
+               "scan_pose_list": [[sid, snap[name]] for sid, name in SERVOS if isinstance(snap[name], int)]}
+    with open(OUT_FILE, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"\n[teach] saved snapshot to {OUT_FILE}")
+    print("[teach] Paste this into modes/ball_follow.py SCAN_POSE:")
+    print("SCAN_POSE = [")
+    for sid, name in SERVOS:
+        v = snap.get(name)
+        if isinstance(v, int):
+            servo_const = {1: "SERVO_GRIPPER", 2: "SERVO_WRIST_ROLL", 3: "SERVO_WRIST_FLEX",
+                           4: "SERVO_ELBOW_FLEX", 5: "SERVO_SHOULDER_LIFT", 6: "SERVO_SHOULDER_PAN"}[sid]
+            print(f"    [{servo_const}, {v}],")
+    print("]\n")
+
+
+def main():
+    global arm, torque_on
+    print("[teach] connecting to xArm...")
+    arm = xarm.Controller('USB')
+    signal.signal(signal.SIGINT, cleanup)
+
+    print("\n" + "=" * 60)
+    print(" SAFETY: This will RELEASE the servos so you can move the arm.")
+    print(" Support the arm with your hand BEFORE pressing Enter, or it")
+    print(" will swing under gravity and could damage itself or the mount.")
+    print("=" * 60)
+    input("[teach] Holding the arm? Press Enter to release torque... ")
+
+    try:
+        arm.servoOff()
+        torque_on = False
+        print("[teach] torque OFF — pose the arm by hand.")
+    except Exception as e:
+        print(f"[teach] servoOff failed: {e}")
+        sys.exit(1)
+
+    t = threading.Thread(target=reader_loop, daemon=True)
+    t.start()
+
+    print("\n[teach] commands:  s = snapshot   h = hold (torque on)   r = release (torque off)   q = quit")
+    while True:
+        try:
+            cmd = input().strip().lower()
+        except EOFError:
+            cleanup()
+        if cmd == "s":
+            save_snapshot()
+        elif cmd == "h":
+            print("[teach] re-enabling torque at current pose...")
+            hold_current_pose()
+            torque_on = True
+        elif cmd == "r":
+            try:
+                arm.servoOff()
+                torque_on = False
+                print("[teach] torque OFF.")
+            except Exception as e:
+                print(f"[teach] servoOff failed: {e}")
+        elif cmd in ("q", "quit", "exit"):
+            cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/renesas-rzg3e-evk/robotic-arm/test_xarm_connect.py
+++ b/renesas-rzg3e-evk/robotic-arm/test_xarm_connect.py
@@ -1,0 +1,22 @@
+import xarm
+import traceback
+
+print('start')
+try:
+    arm = xarm.Controller('USB')
+    print('created', arm)
+    try:
+        v = arm.getBatteryVoltage()
+        print('volt', v)
+    except Exception as e:
+        print('getBattery error', e)
+        traceback.print_exc()
+except BaseException as e:
+    print('exc', e)
+    traceback.print_exc()
+finally:
+    try:
+        arm.servoOff()
+        print('servos off')
+    except:
+        pass

--- a/renesas-rzg3e-evk/robotic-arm/web_view.py
+++ b/renesas-rzg3e-evk/robotic-arm/web_view.py
@@ -1,0 +1,172 @@
+"""View-only MJPEG streamer for the live demo.
+
+Used by main.py when --web-port is passed: every annotated frame from
+the active mode (ball-follow detection overlay, ASL hand landmarks, etc.)
+gets published here so you can watch from any browser on the same LAN
+without needing a display server on the board.
+
+Pattern is identical to browser_calibrate.py's MJPEG plumbing — there's
+no shared module because the two have different control endpoints
+(this one is view-only; the calibrator needs click + save). Keeping
+them separate avoids dragging calibration concerns into the demo path."""
+
+import json
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import cv2
+
+
+PAGE = """<!doctype html>
+<html><head><meta charset="utf-8"><title>RZ/G3E XArm — Live</title>
+<style>
+  body { font: 14px sans-serif; margin: 1em; background: #111; color: #eee; }
+  #stream { display: block; max-width: 100%; }
+  #status { padding: 0.4em 0; font-weight: bold; color: #6cf; }
+</style></head>
+<body>
+<h2>RZ/G3E XArm — live demo view</h2>
+<div id="status">state: ?</div>
+<img id="stream" src="/stream" alt="(camera stream)">
+<script>
+async function poll() {
+  try {
+    const s = await (await fetch('/state')).json();
+    document.getElementById('status').textContent =
+      `state: ${s.state || '?'}   mode: ${s.mode || '?'}   fps_hint: ${s.fps_hint || '?'}`;
+  } catch (e) {}
+}
+setInterval(poll, 1000);
+poll();
+</script>
+</body></html>
+"""
+
+
+class WebView:
+    """Minimal MJPEG + status streamer.
+
+    Call ``publish(frame, state=..., mode=...)`` from your main loop after
+    you've built the annotated display frame. Browser clients pull
+    ``/stream`` (multipart/x-mixed-replace) and ``/state`` (JSON polled
+    once a second by the inline page)."""
+
+    def __init__(self, port=8000, jpeg_quality=80):
+        self._lock = threading.Lock()
+        self._frame_jpeg = b""
+        self._state = ""
+        self._mode = ""
+        self._fps_hint = 0.0
+        self._jpeg_quality = jpeg_quality
+        self._quit = False
+        self._server = ThreadingHTTPServer(("0.0.0.0", port), self._make_handler())
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+        self.port = port
+
+    def publish(self, bgr_frame, state=None, mode=None, fps_hint=None):
+        """Encode ``bgr_frame`` to JPEG and update the labels shown on the
+        page. Cheap (single imencode) — safe to call every frame."""
+        ok, buf = cv2.imencode(
+            ".jpg", bgr_frame,
+            [int(cv2.IMWRITE_JPEG_QUALITY), self._jpeg_quality])
+        if not ok:
+            return
+        with self._lock:
+            self._frame_jpeg = buf.tobytes()
+            if state is not None:
+                self._state = str(state)
+            if mode is not None:
+                self._mode = str(mode)
+            if fps_hint is not None:
+                self._fps_hint = float(fps_hint)
+
+    def stop(self):
+        self._quit = True
+        try:
+            self._server.shutdown()
+            self._server.server_close()
+        except Exception:
+            pass
+
+    def url_hint(self):
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+            s.close()
+        except OSError:
+            ip = "0.0.0.0"
+        return f"http://{ip}:{self.port}/"
+
+    # ---------- internals ----------
+
+    def _serve(self):
+        try:
+            self._server.serve_forever(poll_interval=0.5)
+        except Exception as e:
+            print(f"[web] server stopped: {e}")
+
+    def _make_handler(view):
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, fmt, *args):
+                return
+
+            def do_GET(self):
+                if self.path in ("/", "/index.html"):
+                    body = PAGE.encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/html; charset=utf-8")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+
+                if self.path == "/state":
+                    with view._lock:
+                        payload = {
+                            "state": view._state,
+                            "mode": view._mode,
+                            "fps_hint": round(view._fps_hint, 1),
+                        }
+                    body = json.dumps(payload).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+
+                if self.path == "/stream":
+                    self.send_response(200)
+                    self.send_header(
+                        "Content-Type",
+                        "multipart/x-mixed-replace; boundary=FRAME")
+                    self.send_header("Cache-Control", "no-cache, private")
+                    self.send_header("Pragma", "no-cache")
+                    self.end_headers()
+                    last = None
+                    try:
+                        while not view._quit:
+                            with view._lock:
+                                buf = view._frame_jpeg
+                            if buf and buf is not last:
+                                self.wfile.write(b"--FRAME\r\n")
+                                self.wfile.write(b"Content-Type: image/jpeg\r\n")
+                                self.wfile.write(
+                                    f"Content-Length: {len(buf)}\r\n\r\n".encode())
+                                self.wfile.write(buf)
+                                self.wfile.write(b"\r\n")
+                                last = buf
+                            time.sleep(0.05)
+                    except (BrokenPipeError, ConnectionResetError):
+                        pass
+                    return
+
+                self.send_response(404)
+                self.end_headers()
+
+        return Handler


### PR DESCRIPTION
## Summary

Port of the [TRIA Vision AI Kit 6490 robotic-arm demo](https://github.com/avnet-iotconnect/iotc-tria-vision-ai-kit-robotic-arm) to the **Renesas RZ/G3E EVK**. Controls a Hiwonder XArm 1S over USB, runs autonomous ball pickup via OpenCV HSV detection + visual servoing, and streams telemetry / accepts commands over /IOTCONNECT.

Adapted to RZ/G3E constraints:

- **Browser-based MJPEG calibration + live demo view** — the board has no display server and we install `opencv-python-headless`, so `cv2.imshow` won't render. New `browser_calibrate.py`, `browser_calibrate_offset.py` (MJPEG + click-to-sample), and `web_view.py` (live stream of annotated frames during the demo, exposed via `--web-port`).
- **Stdlib-only `systemdata.py`** — the Yocto Python image strips `resource`, `multiprocessing`, and `statistics`, so `psutil` and `py-cpuinfo` are unusable. Rewritten to read `/proc` and `/sys` directly while keeping the same dataclass shape, so `main.py` is unchanged.
- **`scripts/deps-download.sh` + `scripts/deps-install.sh`** mirror the base RZ/G3E SDK install pattern (host-side wheel fetch → scp → on-board offline unzip into site-packages). Defaults to `cp312` wheels (matches the shipped `rz-vlp 5.0.8` image's Python 3.12.9). `torch` / `torchvision` / `mediapipe` stay best-effort, so the `asl` mode is documented as best-effort accordingly.
- **Demo defaults** — `--mode ball`, `--camera 0` (matches `/dev/video0`), and `start.sh` drops `stdbuf` (busybox doesn't ship it).

Top-level [`renesas-rzg3e-evk/README.md`](../blob/add-rzg3e-robotic-arm-demo/renesas-rzg3e-evk/README.md) gets a "More Demos" link to the new folder.

## Test plan

Verified end-to-end on a real RZ/G3E EVK + Hiwonder XArm 1S + Logitech Brio 100 + LAN:

- [x] `deps-download.sh` fetches cp312 aarch64 wheels (skips torch/mediapipe as expected)
- [x] `deps-install.sh` reports `OK` for `cv2`, `numpy`, `xarm`, `hid`, `avnet.iotconnect.sdk.lite`
- [x] IoTConnect onboarding: cert + key + config recognized; `DeviceConfig.from_iotc_device_config_json_file()` parses cleanly
- [x] `./calibrate.sh` opens MJPEG stream at `http://<board-ip>:8000/`; click-to-sample works; **Save & Quit** writes `ball_color.json`
- [x] `./calibrate_offset.sh` reports recommended `CAM_GRIPPER_OFFSET_X/Y` and `TARGET_RADIUS_PX`
- [x] `./start.sh --headless --web-port 8000` connects arm, homes, opens camera at `/dev/video0`, scans for ball, publishes telemetry to /IOTCONNECT
- [x] Live web view shows `state: SCANNING/TRACKING/...` with annotated overlay
- [x] `systemdata.py` reports real RZ/G3E values: ARM Cortex-A55 @ 1700 MHz, 4 cores, `cpu-thermal` zone read